### PR TITLE
Modifying interaction layer to include 2 MLPs in DLRM (#382)

### DIFF
--- a/examples/torchrec_example.py
+++ b/examples/torchrec_example.py
@@ -22,7 +22,7 @@ from torchrec.distributed.embeddingbag import EmbeddingBagCollectionSharder
 from torchrec.distributed.planner import EmbeddingShardingPlanner, Topology
 from torchrec.distributed.planner.types import ParameterConstraints
 from torchrec.distributed.types import ShardingType
-from torchrec.models.dlrm import DLRMTrain
+from torchrec.models.dlrm import DLRM, DLRMTrain
 from torchrec.optim.keyed import KeyedOptimizerWrapper
 
 EPOCH_SIZE = 10
@@ -106,7 +106,7 @@ def train(work_dir: str, max_epochs: int, snapshot_path: Optional[str] = None):
 
     torch.manual_seed(42)
 
-    model = DLRMTrain(
+    dlrm_model = DLRM(
         embedding_bag_collection=torchrec.EmbeddingBagCollection(
             device="meta",
             tables=TABLES,
@@ -115,6 +115,7 @@ def train(work_dir: str, max_epochs: int, snapshot_path: Optional[str] = None):
         dense_arch_layer_sizes=[64, EMBEDDING_DIM],
         over_arch_layer_sizes=[64, NUM_CLASSES],
     )
+    model = DLRMTrain(dlrm_model)
 
     dmp = torchrec.distributed.DistributedModelParallel(
         module=model,


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/torchrec/pull/382

X-link: https://github.com/facebookresearch/dlrm/pull/242

This diff adds 2 MLPs to the interaction layer in DLRM for MLPerf update. New DLRM module called DLRMV2 can be realized by --dlrmv2 argument. Additional arguments for the interaction MLPs are --interaction_branch1_layer_sizes and --interaction_branch2_layer_sizes to pass in the MLP sizes. The output dimension of the interaction MLPs must be a multiple of the embedding dimension.

DLRMTrain now takes in a DLRM/DLRMV2 module at construction time.

Reviewed By: colin2328, samiwilf

Differential Revision: D35861688

