### PR TITLE
convert state dict keys to valid filenames

### DIFF
--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -23,7 +23,9 @@ _OBJ = {
         3,
         {"qux": 4, "quxx": [5, OrderedDict(quuz=6, corge=[7, 8, 9])]},
     ],
+    "x/y": {"%a/b": 10},
 }
+
 _EXPECTED_MANIFEST = {
     "": DictEntry(keys=["foo", "bar", "baz"]),
     "baz": ListEntry(),
@@ -32,6 +34,17 @@ _EXPECTED_MANIFEST = {
     "baz/2/quxx/1": OrderedDictEntry(keys=["quuz", "corge"]),
     "baz/2/quxx/1/corge": ListEntry(),
 }
+
+_EXPECTED_MANIFEST = {
+    "": DictEntry(keys=["foo", "bar", "baz", "x/y"]),
+    "baz": ListEntry(),
+    "baz/2": DictEntry(keys=["qux", "quxx"]),
+    "baz/2/quxx": ListEntry(),
+    "baz/2/quxx/1": OrderedDictEntry(keys=["quuz", "corge"]),
+    "baz/2/quxx/1/corge": ListEntry(),
+    "x%2Fy": DictEntry(keys=["%a/b"]),
+}
+
 _EXPECTED_FLATTENED = {
     "foo": 0,
     "bar": 1,
@@ -43,6 +56,7 @@ _EXPECTED_FLATTENED = {
     "baz/2/quxx/1/corge/0": 7,
     "baz/2/quxx/1/corge/1": 8,
     "baz/2/quxx/1/corge/2": 9,
+    "x%2Fy/%25a%2Fb": 10,
 }
 
 
@@ -52,6 +66,8 @@ class FlattenTest(unittest.TestCase):
 
     def test_flatten(self) -> None:
         manifest, flattened = flatten(obj=_OBJ)
+        print(manifest)
+        print(flattened)
         self.assertDictEqual(manifest, _EXPECTED_MANIFEST)
         self.assertDictEqual(flattened, _EXPECTED_FLATTENED)
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -20,8 +20,24 @@ class SnapshotTest(unittest.TestCase):
         self.maxDiff = None
 
     def test_state_dict(self) -> None:
-        foo = torchsnapshot.StateDict(a=torch.rand(40, 40), b=torch.rand(40, 40), c=42)
-        bar = torchsnapshot.StateDict(a=torch.rand(40, 40), b=torch.rand(40, 40), c=43)
+        foo = torchsnapshot.StateDict(
+            {
+                "a": torch.rand(40, 40),
+                "b": torch.rand(40, 40),
+                "c": 42,
+                "d/e": 43,
+                "[@x]->&y^": {"(z)": 44},
+            },
+        )
+        bar = torchsnapshot.StateDict(
+            {
+                "a": torch.rand(40, 40),
+                "b": torch.rand(40, 40),
+                "c": 42,
+                "d/e": 43,
+                "[@x]->&y^": {"(z)": 44},
+            },
+        )
         self.assertFalse(check_state_dict_eq(foo.state_dict(), bar.state_dict()))
         self.assertTrue(type(foo.state_dict()) == dict)
 


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/facebookresearch/torchsnapshot/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

Previously, if a state dict had an invalid character, the snapshot would not restore properly. (ex: `StateDict({'x/y': 5})`. Now, we encode the key using urllib, converting it into a valid ASCII sequence.

The YAML metadata may look a little strange. Example:

```
  0/e:
    type: dict
    keys:
    - x/z
    - 3
  0/e/x%2Fz:
    type: object
    location: 0/e/x%2Fz
    serializer: torch_save
    obj_type: builtins.int
    replicated: false
  0/e/3:
    type: object
    location: 0/e/3
    serializer: torch_save
    obj_type: builtins.int
    replicated: false
```

Some possible solutions:

1) leave it as is
2) have the name be the original key.  
  a. remove the string encoding when we write the yaml file. seem a little hacky
  b. create a new `name` field in ObjectEntry, and `flatten` would require us to store both the original name and the converted key. Thoughts?

Test plan:

unit test

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
