### PR TITLE
Experimental DeepSpeed integration and benchmark

### DIFF
--- a/benchmarks/deepspeed_opt/main.py
+++ b/benchmarks/deepspeed_opt/main.py
@@ -1,0 +1,169 @@
+import argparse
+import logging
+import os
+import time
+import uuid
+from enum import Enum
+from typing import Optional
+
+import deepspeed
+import torch
+import torch.distributed as dist
+
+from deepspeed import DeepSpeedEngine
+from torchsnapshot.tricks.deepspeed import patch_engine_to_use_torchsnapshot
+from transformers import OPTConfig, OPTModel
+from transformers.deepspeed import HfDeepSpeedConfig
+
+dschf: Optional[HfDeepSpeedConfig] = None
+
+
+# https://arxiv.org/pdf/2205.01068.pdf
+TRAIN_BATCH_SIZE = 1024**2
+NUM_HIDDEN_LAYERS = 48
+NUM_ATTENTION_HEADS = 56
+HIDDEN_SIZE = 7168
+
+
+class BenchmarkType(Enum):
+    TORCHSNAPSHOT = "torchsnapshot"
+    DEEPSPEED = "deepspeed"
+
+    def __str__(self):
+        return self.value
+
+
+def rank_0_print(msg: str) -> None:
+    if dist.get_rank() == 0:
+        print(msg)
+
+
+def initialize_deepspeed_opt() -> DeepSpeedEngine:
+    ds_config = {
+        "train_batch_size": TRAIN_BATCH_SIZE,
+        "fp16": {
+            "enabled": True,
+        },
+        "zero_optimization": {
+            "stage": 3,
+        },
+        "optimizer": {
+            "type": "Adam",
+            "params": {
+                "lr": 2e-4,
+                "weight_decay": 0.01,
+            },
+        },
+    }
+    # HfDeepSpeedConfig must be created before instantiating the model and and kept alive.
+    # https://huggingface.co/docs/transformers/main_classes/deepspeed#nontrainer-deepspeed-integration
+    dschf = HfDeepSpeedConfig(ds_config)  # noqa
+
+    with deepspeed.zero.Init():
+        config = OPTConfig(
+            num_hidden_layers=NUM_HIDDEN_LAYERS,
+            num_attention_heads=NUM_ATTENTION_HEADS,
+            hidden_size=HIDDEN_SIZE,
+        )
+        model = OPTModel(config)
+
+    engine, _, _, _ = deepspeed.initialize(
+        model=model, model_parameters=model.parameters(), config_params=ds_config
+    )
+    return engine
+
+
+def benchmark_torchsnapshot(
+    engine: DeepSpeedEngine, save_dir: str, benchmark_load: bool
+) -> None:
+    patch_engine_to_use_torchsnapshot(engine)
+
+    rank_0_print("Saving a checkpoint with torchsnapshot...")
+    begin_ts = time.monotonic()
+    engine.save_checkpoint(save_dir=save_dir)
+    rank_0_print(
+        f"Completed saving with torchsnapshot (snapshot path: {save_dir}).\n"
+        f"Took {time.monotonic() - begin_ts:.2f} seconds."
+    )
+
+    if benchmark_load:
+        del engine
+        engine = initialize_deepspeed_opt()
+        patch_engine_to_use_torchsnapshot(engine)
+
+        rank_0_print("Loading the checkpoint with torchsnapshot...")
+        begin_ts = time.monotonic()
+        engine.load_checkpoint(load_dir=save_dir)
+        rank_0_print(
+            f"Completed loading with torchsnapshot.\n"
+            f"Took {time.monotonic() - begin_ts:.2f} seconds."
+        )
+
+
+def benchmark_deepspeed(
+    engine: DeepSpeedEngine, save_dir: str, benchmark_load: bool
+) -> None:
+    rank_0_print("Saving a checkpoint with DeepSpeedEngine.save_checkpoint()...")
+    begin_ts = time.monotonic()
+    engine.save_checkpoint(save_dir=save_dir)
+    rank_0_print(
+        f"Completed saving with DeepSpeedEngine.save_checkpoint() (save_dir: {save_dir}).\n"
+        f"Took {time.monotonic() - begin_ts:.2f} seconds."
+    )
+    if benchmark_load:
+        del engine
+        engine = initialize_deepspeed_opt()
+        rank_0_print("Loading the checkpoint with DeepSpeedEngine.save_checkpoint()...")
+        begin_ts = time.monotonic()
+        engine.load_checkpoint(load_dir=save_dir)
+        rank_0_print(
+            f"Completed loading with DeepSpeedEngine.load_checkpoint().\n"
+            f"Took {time.monotonic() - begin_ts:.2f} seconds."
+        )
+
+
+def main(benchmark_type: BenchmarkType, work_dir: str, benchmark_load: bool) -> None:
+    logger = logging.getLogger("torchsnapshot.scheduler")
+    logger.setLevel(logging.DEBUG)
+
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+
+    save_dir = f"{work_dir}/{uuid.uuid4()}"
+    object_list = [None] * dist.get_world_size()
+    object_list[dist.get_rank()] = save_dir
+    dist.broadcast_object_list(object_list=object_list, src=0)
+    save_dir = object_list[0]
+
+    engine = initialize_deepspeed_opt()
+    if benchmark_type == BenchmarkType.TORCHSNAPSHOT:
+        benchmark_torchsnapshot(
+            engine=engine, save_dir=save_dir, benchmark_load=benchmark_load
+        )
+    elif benchmark_type == BenchmarkType.DEEPSPEED:
+        benchmark_deepspeed(
+            engine=engine, save_dir=save_dir, benchmark_load=benchmark_load
+        )
+    else:
+        raise ValueError(f"Unrecognized benchmark type: {benchmark_type}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--benchmark-type",
+        type=BenchmarkType,
+        choices=list(BenchmarkType),
+        default=BenchmarkType.TORCHSNAPSHOT,
+    )
+    parser.add_argument("--work-dir", default="/tmp")
+    parser.add_argument("--benchmark-load", action="store_true", default=False)
+
+    args: argparse.Namespace = parser.parse_args()
+    main(
+        benchmark_type=args.benchmark_type,
+        work_dir=args.work_dir,
+        benchmark_load=args.benchmark_load,
+    )

--- a/benchmarks/deepspeed_opt/run.slurm
+++ b/benchmarks/deepspeed_opt/run.slurm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+#SBATCH --exclusive
+#SBATCH --nodes 2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-task=8
+
+RDZV_ENDPOINT=$(scontrol show hostnames $SLURM_JOB_NODELIST | head -n 1)
+
+srun python3 -m torch.distributed.run --nnodes=$SLURM_NNODES --nproc_per_node=$SLURM_GPUS_PER_TASK --rdzv_id=$SLURM_JOB_ID --rdzv_backend=c10d --rdzv_endpoint=$RDZV_ENDPOINT --max_restarts 0 main.py $@

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -179,7 +179,7 @@ class ShardedTensorIOPreparer:
 
 @torch.jit.script
 def tensor_copy(dst: torch.Tensor, src: torch.Tensor) -> None:
-    dst.copy_(src)
+    dst.detach().copy_(src)  # pragma: no cover
 
 
 class ShardedTensorBufferConsumer(BufferConsumer):
@@ -225,7 +225,7 @@ class ShardedTensorBufferConsumer(BufferConsumer):
 
 @torch.jit.script
 def tensor_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
-    return tensor.to("cpu")
+    return tensor.to("cpu")  # pragma: no cover
 
 
 class TensorBufferStager(BufferStager):

--- a/torchsnapshot/tricks/deepspeed.py
+++ b/torchsnapshot/tricks/deepspeed.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import logging
+from types import MethodType
+from typing import Any, Dict
+
+from deepspeed import DeepSpeedEngine, version
+from deepspeed.runtime.zero.stage3 import DeepSpeedZeroOptimizer_Stage3
+from torchsnapshot import Snapshot, StateDict
+
+logger = logging.getLogger(__name__)
+
+
+def _save_zero_checkpoint(self, save_path, tag):
+    app_state = {
+        "optimizer": self.optimizer,
+        "objects": StateDict(ds_config=self.config, ds_version=version),
+    }
+    Snapshot.async_take(path=save_path, app_state=app_state)
+    # TODO: demonstrate how torchsnapshot can help with zero_to_fp32.py
+    if self.global_rank == 0:
+        self._copy_recovery_script(save_path)
+
+
+class Zero3StateAdapter:
+    """
+    Adapts DeepSpeedZeroOptimizer_Stage3 to expose conventional .state_dict()
+    and .load_state_dict().
+
+    Usage:
+
+    >>> app_state = {
+    >>>     "optimizer": Zero3StateAdapter(zero3_optimizer),
+    >>> }
+    >>> Snapshot.take(path=path, app_state=app_state)
+    """
+
+    def __init__(
+        self,
+        optimizer: DeepSpeedZeroOptimizer_Stage3,
+        load_optimizer_states: bool = True,
+        load_from_fp32_weights: bool = False,
+    ) -> None:
+        self.optimizer = optimizer
+        self.load_optimizer_state = load_optimizer_states
+        self.load_from_fp32_weights = load_from_fp32_weights
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.optimizer._rigid_load_state_dict(
+            state_dict=state_dict, load_optimizer_states=self.load_optimizer_state
+        )
+        if len(self.optimizer.persistent_parameters) > 0:
+            self.optimizer.persistent_parameters[0].partition(
+                self.optimizer.persistent_parameters
+            )
+            self.optimizer.persistent_parameters[0].all_gather(
+                self.optimizer.persistent_parameters
+            )
+
+
+def _load_zero_checkpoint(self, load_dir, tag, load_optimizer_states=True):
+    snapshot = Snapshot(path=load_dir)
+    app_state = {
+        "optimizer": Zero3StateAdapter(
+            optimizer=self.optimizer,
+            load_optimizer_states=load_optimizer_states,
+            load_from_fp32_weights=self.zero_load_from_fp32_weights(),
+        )
+    }
+    snapshot.restore(app_state=app_state)
+    return True
+
+
+def patch_engine_to_use_torchsnapshot(engine: DeepSpeedEngine) -> None:
+    """
+    Patch a DeepSpeedEngine to use torchsnapshot to save its optimizer states.
+
+    Args:
+        engine: The DeepSpeedEngine to patch.
+
+    WARNING: This function is not a proper integration with deepspeed. Its
+    purpose is to demonstrate/benchmark a potential integration. Only use it at
+    your own risk.
+    """
+    if not isinstance(engine.optimizer, DeepSpeedZeroOptimizer_Stage3):
+        raise RuntimeError(
+            "patch_engine_to_use_torchsnapshot only supports DeepSpeedZeroOptimizer_Stage3."
+        )
+    engine._save_zero_checkpoint = MethodType(_save_zero_checkpoint, engine)
+    engine._load_zero_checkpoint = MethodType(_load_zero_checkpoint, engine)


### PR DESCRIPTION
Summary:
- Added an experimental DeepSpeed integration that allows `DeepSpeedEngine` to save `DeepSpeedZeroOptimizer_Stage3` with `torchsnapshot`.
  - The integration is hacky and is only meant for demonstration/benchmarking purposes.
- Added a benchmark for the integration