### PR TITLE
Implement chunked tensor read

### DIFF
--- a/benchmarks/load_tensor/main.py
+++ b/benchmarks/load_tensor/main.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+import tempfile
+import time
+
+import torch
+from torchsnapshot import Snapshot, StateDict
+from torchsnapshot.rss_profiler import measure_rss_deltas
+
+logging.basicConfig(level=logging.INFO)
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+TENSOR_DIMS = (50000, 50000)
+MEMORY_BUDGET_BYTES = 20 * 1024**2
+
+
+def benchmark_torchsnapshot(path: str, gpu_tensor: torch.Tensor) -> None:
+    app_state = {
+        "state": StateDict(
+            tensor=gpu_tensor,
+        )
+    }
+    snapshot = Snapshot.take(path=path, app_state=app_state)
+
+    ts_begin = time.monotonic()
+    rss_deltas = []
+    logger.info("Loading the tensor with torchsnapshot (without memory budget)...")
+    with measure_rss_deltas(rss_deltas=rss_deltas):
+        snapshot.read_object(path="0/state/tensor", obj_out=gpu_tensor)
+    logger.info(
+        f"Took {time.monotonic() - ts_begin:.2f} seconds. "
+        f"Peak RSS delta: {max(rss_deltas) // 1024**2}MB"
+    )
+
+    ts_begin = time.monotonic()
+    rss_deltas = []
+    logger.info(
+        f"Loading the tensor with torchsnapshot "
+        f"(with a {MEMORY_BUDGET_BYTES // 1024**2:.2f}MB memory budget)..."
+    )
+    with measure_rss_deltas(rss_deltas=rss_deltas):
+        snapshot.read_object(
+            path="0/state/tensor",
+            obj_out=gpu_tensor,
+            memory_budget_bytes=MEMORY_BUDGET_BYTES,
+        )
+    logger.info(
+        f"Took {time.monotonic() - ts_begin:.2f}. "
+        f"Peak RSS delta: {max(rss_deltas) // 1024**2}MB"
+    )
+
+
+def benchmark_torch_save(path: str, gpu_tensor: torch.Tensor) -> None:
+    tensor_path = os.path.join(path, "foo")
+    torch.save(gpu_tensor, tensor_path)
+
+    ts_begin = time.monotonic()
+    rss_deltas = []
+    logger.info("Loading the tensor with torch.load()...")
+    with measure_rss_deltas(rss_deltas=rss_deltas):
+        loaded = torch.load(tensor_path, map_location="cpu")
+        gpu_tensor.copy_(loaded)
+
+    logger.info(
+        f"Took {time.monotonic() - ts_begin:.2f}. "
+        f"Peak RSS delta: {max(rss_deltas) // 1024**2}MB"
+    )
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda:0")
+    gpu_tensor = torch.rand(*TENSOR_DIMS, device=device)
+    with tempfile.TemporaryDirectory() as path:
+        benchmark_torch_save(path=path, gpu_tensor=gpu_tensor)
+    with tempfile.TemporaryDirectory() as path:
+        benchmark_torchsnapshot(path=path, gpu_tensor=gpu_tensor)

--- a/tests/test_rss_profiler.py
+++ b/tests/test_rss_profiler.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+import unittest
+
+import torch
+from torchsnapshot.rss_profiler import measure_rss_deltas
+
+
+class RSSProfilerTest(unittest.TestCase):
+    def test_rss_profiler(self) -> None:
+        rss_deltas = []
+        with measure_rss_deltas(rss_deltas=rss_deltas):
+            torch.randn(5000, 5000)
+            time.sleep(2)

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -340,16 +340,59 @@ class TensorIOPreparer:
         cls,
         entry: TensorEntry,
         tensor_out: Optional[torch.Tensor] = None,
+        buffer_size_limit_bytes: Optional[int] = None,
     ) -> List[ReadReq]:
         if tensor_out is None:
             raise RuntimeError(
                 "Reading a Tensor without a runtime object is not yet supported."
             )
-        buffer_consumer = TensorBufferConsumer(
-            tensor=tensor_out,
-            entry=entry,
+
+        if (
+            buffer_size_limit_bytes is None
+            or entry.serializer != Serializer.BUFFER_PROTOCOL.value
+        ):
+            buffer_consumer = TensorBufferConsumer(
+                tensor=tensor_out,
+                entry=entry,
+            )
+            return [ReadReq(path=entry.location, buffer_consumer=buffer_consumer)]
+
+        num_chunks = math.ceil(
+            cls.get_tensor_size_from_entry(entry) / buffer_size_limit_bytes
         )
-        return [ReadReq(path=entry.location, buffer_consumer=buffer_consumer)]
+        # Try to flatten the tensor without copying to achieve better chunking granularity.
+        # This is only possible if the tensor satisfies the contiguity condition described in:
+        # https://pytorch.org/docs/stable/generated/torch.Tensor.view.html#torch.Tensor.view
+        try:
+            tensor_out = tensor_out.view(-1)
+        except RuntimeError:
+            pass
+        chunks = torch.chunk(tensor_out, chunks=num_chunks, dim=0)
+        element_size = dtype_to_element_size(string_to_dtype(entry.dtype))
+
+        read_reqs = []
+        offset = 0
+        for chunk in chunks:
+            chunk_sz_bytes = chunk.nelement() * element_size
+            buffer_consumer = TensorBufferConsumer(
+                tensor=chunk,
+                entry=TensorEntry(
+                    location=entry.location,
+                    serializer=entry.serializer,
+                    dtype=entry.dtype,
+                    shape=list(chunk.shape),
+                    replicated=entry.replicated,
+                ),
+            )
+            read_reqs.append(
+                ReadReq(
+                    path=entry.location,
+                    byte_range=(offset, offset + chunk_sz_bytes),
+                    buffer_consumer=buffer_consumer,
+                )
+            )
+            offset += chunk_sz_bytes
+        return read_reqs
 
     @staticmethod
     def get_tensor_size_from_entry(entry: TensorEntry) -> int:
@@ -463,7 +506,11 @@ def prepare_write(
     return entry, obj_write_req
 
 
-def prepare_read(entry: Entry, obj_out: Optional[Any] = None) -> List[ReadReq]:
+def prepare_read(
+    entry: Entry,
+    obj_out: Optional[Any] = None,
+    buffer_size_limit_bytes: Optional[int] = None,
+) -> List[ReadReq]:
     """
     Prepare read for an object.
 
@@ -482,7 +529,9 @@ def prepare_read(entry: Entry, obj_out: Optional[Any] = None) -> List[ReadReq]:
             )
         return ShardedTensorIOPreparer.prepare_read(entry, obj_out)
     elif isinstance(entry, TensorEntry):
-        return TensorIOPreparer.prepare_read(entry, obj_out)
+        return TensorIOPreparer.prepare_read(
+            entry, obj_out, buffer_size_limit_bytes=buffer_size_limit_bytes
+        )
     elif isinstance(entry, ObjectEntry):
         return ObjectIOPreparer.prepare_read(entry, obj_out)
     else:

--- a/torchsnapshot/io_types.py
+++ b/torchsnapshot/io_types.py
@@ -10,7 +10,7 @@ import asyncio
 import io
 from concurrent.futures import Executor
 from dataclasses import dataclass, field
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 
 
 BufferType = Union[bytes, memoryview]
@@ -48,12 +48,14 @@ class BufferConsumer:
 class ReadReq:
     path: str
     buffer_consumer: BufferConsumer
+    byte_range: Optional[Tuple[int, int]] = None
 
 
 @dataclass
 class IOReq:
     path: str
     buf: io.BytesIO = field(default_factory=io.BytesIO)
+    byte_range: Optional[Tuple[int, int]] = None
 
 
 class StoragePlugin(abc.ABC):

--- a/torchsnapshot/rss_profiler.py
+++ b/torchsnapshot/rss_profiler.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import time
+from contextlib import contextmanager
+from datetime import timedelta
+from threading import Event, Thread
+from typing import Generator, List
+
+import psutil
+
+_DEFAULT_MEASURE_INTERVAL = timedelta(milliseconds=100)
+
+
+def _measure(
+    rss_deltas: List[int],
+    interval: timedelta,
+    baseline_rss_bytes: int,
+    stop_event: Event,
+) -> None:
+    p = psutil.Process()
+    while not stop_event.is_set():
+        rss_deltas.append(p.memory_info().rss - baseline_rss_bytes)
+        time.sleep(interval.total_seconds())
+
+
+@contextmanager
+def measure_rss_deltas(
+    rss_deltas: List[int], interval: timedelta = _DEFAULT_MEASURE_INTERVAL
+) -> Generator[None, None, None]:
+    """
+    A context manager that periodically measures RSS (resident set size) delta.
+
+    The baseline RSS is measured when the context manager is initialized.
+
+    Args:
+        rss_deltas: The list to which the measured RSS deltas (measured in
+            bytes) are appended.
+        interval: The interval at which RSS deltas are measured.
+    """
+    baseline_rss_bytes = psutil.Process().memory_info().rss
+    stop_event = Event()
+    thread = Thread(
+        target=_measure, args=(rss_deltas, interval, baseline_rss_bytes, stop_event)
+    )
+    thread.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        thread.join()

--- a/torchsnapshot/storage_plugins/fs.py
+++ b/torchsnapshot/storage_plugins/fs.py
@@ -34,9 +34,16 @@ class FSStoragePlugin(StoragePlugin):
 
     async def read(self, io_req: IOReq) -> None:
         path = os.path.join(self.root, io_req.path)
+        byte_range = io_req.byte_range
 
         async with aiofiles.open(path, "rb") as f:
-            io_req.buf = io.BytesIO(await f.read())
+            if byte_range is None:
+                io_req.buf = io.BytesIO(await f.read())
+            else:
+                offset = byte_range[0]
+                size = byte_range[1] - byte_range[0]
+                await f.seek(offset)
+                io_req.buf = io.BytesIO(await f.read(size))
 
     async def delete(self, path: str) -> None:
         path = os.path.join(self.root, path)


### PR DESCRIPTION
Summary:
- Introduced argument buffer_size_limit_bytes to TensorIOPreparer.read(). When
  specified, the size of the memory buffer for fulfilling the read is limited,
  and the read is potentially split into multiple read requests.
- Introduced argument memory_budget_bytes to Snapshot.read_object(). When
  specified, a buffer_size_limit_bytes is passed to TensorIOPreparer.read().
- Benchmark for reading a 10GB tensor from file system to GPU:
  - torch.load
    - Peak RSS delta: 9538MB
    - Duration: 9.09 seconds
  - torchsnapshot with buffer_size_limit_bytes
    - Peak RSS delta: 26MB
    - Duration: 6.42 seconds

Differential Revision: D38137209

