### PR TITLE
Use dist.broadcast_object_list for PGWrapper.scatter_object_list when the pg's backend is NCCL

### DIFF
--- a/tests/test_pg_wrapper.py
+++ b/tests/test_pg_wrapper.py
@@ -1,7 +1,16 @@
-#!/usr/bin/env fbpython
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
+# pyre-ignore-all-errors[56]
+
+import os
 import unittest
+
+import torch
 
 import torch.distributed as dist
 import torch.distributed.launcher as pet
@@ -9,11 +18,14 @@ from torchsnapshot.pg_wrapper import PGWrapper
 from torchsnapshot.test_utils import get_pet_launch_config
 
 
-class TestPgWrapper(unittest.TestCase):
+class TestPGWrapper(unittest.TestCase):
     @staticmethod
-    def _worker() -> None:
+    def _worker(backend: str) -> None:
         tc = unittest.TestCase()
-        dist.init_process_group(backend="gloo")
+        dist.init_process_group(backend=backend)
+        if backend == "nccl":
+            local_rank = int(os.environ["LOCAL_RANK"])
+            torch.cuda.set_device(torch.device(f"cuda:{local_rank}"))
         pg_wrapper = PGWrapper(pg=None)
         output_list = [None]
         input_list = [["foo"], ["bar"], ["quaz"]]
@@ -21,16 +33,18 @@ class TestPgWrapper(unittest.TestCase):
         rank = dist.get_rank()
         tc.assertEqual(output_list, [input_list[rank]])
 
-    def test_scatter_obj_list_dist_initialized(self) -> None:
+    def test_scatter_obj_list_gloo(self) -> None:
         lc = get_pet_launch_config(nproc=3)
-        pet.elastic_launch(lc, entrypoint=self._worker)()
+        pet.elastic_launch(lc, entrypoint=self._worker)("gloo")
+
+    @unittest.skipUnless(torch.cuda.is_available(), "This test requires GPU to run.")
+    def test_scatter_obj_list_nccl(self) -> None:
+        lc = get_pet_launch_config(nproc=3)
+        pet.elastic_launch(lc, entrypoint=self._worker)("nccl")
 
     def test_scatter_obj_list_dist_uninitialized(self) -> None:
         pg_wrapper = PGWrapper(pg=None)
         output_list = [None]
-        src_rank = 1
-        input_list = [["foo"], ["bar"], ["quaz"]]
-        pg_wrapper.scatter_object_list(
-            output_list=output_list, input_list=input_list, src=src_rank
-        )
-        self.assertEqual(output_list, [input_list[src_rank]])
+        input_list = [["foo"]]
+        pg_wrapper.scatter_object_list(output_list=output_list, input_list=input_list)
+        self.assertEqual(output_list, [input_list[0]])

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -569,7 +569,6 @@ class Snapshot:
             replicated_paths_list = [[]]
 
         local_paths_list = [[]]
-        # pyre-ignore
         pg.scatter_object_list(local_paths_list, paths_partition, src=0)
         pg.broadcast_object_list(replicated_paths_list, src=0)
         local_paths = local_paths_list[0]


### PR DESCRIPTION
Summary: As title.

Reviewed By: edward-io

Differential Revision: D38223540

