### PR TITLE
Improve scheduler logging and enable by default

### DIFF
--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -688,6 +688,8 @@ path "{logical_path}" which was not available to rank {rank}.
         rank = pg_wrapper.get_rank()
 
         # coalesce path
+        # TODO: use a single all_gather for both path and replicated.
+        # Only emit a single message for path inconsistency.
         obj_list = [path]
         pg_wrapper.broadcast_object_list(obj_list, src=0)
         if obj_list[0] != path:


### PR DESCRIPTION
```
INFO:torchsnapshot.scheduler:Rank   Stage-able      Staging   Write-able      Writing   RSS Delta (GB)   Memory Budget (GB)  Data Written (GB)
INFO:torchsnapshot.scheduler:-----------------------------------------------------------------------------------------------------------------
INFO:torchsnapshot.scheduler:   1            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   6            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   4            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   5            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   7            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   3            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   2            0           36            1            4             2.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   1            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   4            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   5            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   7            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   6            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   3            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   2            0           30            1           10             5.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   1            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   4            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   6            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   7            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   2            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   5            0           24            1           16             8.51          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   3            0           24            1           16             8.28          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   1            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   4            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   6            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   5            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   2            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   7            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   3            0           18            7           16            11.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   1            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   4            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   6            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   2            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   5            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   7            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   3            0           12           13           16            14.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   4            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   1            0            6           18           16            16.54          12.97/32.00               0.50
INFO:torchsnapshot.scheduler:   6            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   2            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   5            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   7            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   3            0            6           19           16            17.04          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:   0            0            0           25           16            19.54          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:----------------------------------- Rank 0 completed staging in 15.43 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   4            0            0           25           16            19.54          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:----------------------------------- Rank 4 completed staging in 15.52 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   1            0            0           24           16            19.04          12.97/32.00               0.50
INFO:torchsnapshot.scheduler:----------------------------------- Rank 1 completed staging in 15.59 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   6            0            0           25           16            19.54          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:----------------------------------- Rank 6 completed staging in 15.72 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   2            0            0           24           16            19.04          12.97/32.00               0.50
INFO:torchsnapshot.scheduler:----------------------------------- Rank 2 completed staging in 15.99 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   5            0            0           25           16            19.54          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:----------------------------------- Rank 5 completed staging in 16.28 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   7            0            0           25           16            19.54          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:----------------------------------- Rank 7 completed staging in 16.35 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   3            0            0           25           16            19.54          12.47/32.00               0.00
INFO:torchsnapshot.scheduler:----------------------------------- Rank 3 completed staging in 16.79 seconds -----------------------------------
INFO:torchsnapshot.scheduler:   2            0            0           19           16            16.78          15.23/32.00               2.77
INFO:torchsnapshot.scheduler:   7            0            0           20           16            17.28          14.73/32.00               2.27
INFO:torchsnapshot.scheduler:   1            0            0           19           16            16.78          15.23/32.00               2.77
INFO:torchsnapshot.scheduler:   0            0            0           20           16            17.28          14.73/32.00               2.27
INFO:torchsnapshot.scheduler:   6            0            0           20           16            17.28          14.73/32.00               2.27
INFO:torchsnapshot.scheduler:   1            0            0           14           16            14.28          17.73/32.00               5.27
INFO:torchsnapshot.scheduler:   5            0            0           20           16            17.04          14.97/32.00               2.50
INFO:torchsnapshot.scheduler:   7            0            0           14           16            14.28          17.73/32.00               5.27
INFO:torchsnapshot.scheduler:   4            0            0           20           16            17.28          14.73/32.00               2.27
INFO:torchsnapshot.scheduler:   2            0            0           14           16            14.28          17.73/32.00               5.27
INFO:torchsnapshot.scheduler:   4            0            0           14           16            14.28          17.73/32.00               5.27
INFO:torchsnapshot.scheduler:   2            0            0            9           16            11.78          20.23/32.00               7.77
INFO:torchsnapshot.scheduler:   5            0            0           14           16            14.04          17.97/32.00               5.50
INFO:torchsnapshot.scheduler:   6            0            0           14           16            14.28          17.73/32.00               5.27
INFO:torchsnapshot.scheduler:   3            0            0           20           16            17.04          14.97/32.00               2.50
INFO:torchsnapshot.scheduler:   0            0            0           14           16            14.28          17.73/32.00               5.27
INFO:torchsnapshot.scheduler:   1            0            0            9           16            11.78          20.23/32.00               7.77
INFO:torchsnapshot.scheduler:   3            0            0           14           16            14.04          17.97/32.00               5.50
INFO:torchsnapshot.scheduler:   7            0            0            8           16            11.78          20.23/32.00               7.77
INFO:torchsnapshot.scheduler:   4            0            0            8           16            11.78          20.23/32.00               7.77
INFO:torchsnapshot.scheduler:   7            0            0            2           16             8.78          23.23/32.00              10.77
INFO:torchsnapshot.scheduler:   2            0            0            4           16             9.78          22.23/32.00               9.77
INFO:torchsnapshot.scheduler:   1            0            0            4           16             9.78          22.23/32.00               9.77
INFO:torchsnapshot.scheduler:   3            0            0            8           16            11.54          20.47/32.00               8.00
INFO:torchsnapshot.scheduler:   1            0            0            0           15             7.28          24.73/32.00              12.27
INFO:torchsnapshot.scheduler:   5            0            0            8           16            11.04          20.97/32.00               8.50
INFO:torchsnapshot.scheduler:   7            0            0            0           12             5.78          26.23/32.00              13.77
INFO:torchsnapshot.scheduler:   6            0            0            8           16            11.28          20.73/32.00               8.27
INFO:torchsnapshot.scheduler:   1            0            0            0           10             5.01          27.00/32.00              14.53
INFO:torchsnapshot.scheduler:   2            0            0            0           15             7.28          24.73/32.00              12.27
INFO:torchsnapshot.scheduler:   5            0            0            2           16             8.04          23.97/32.00              11.50
INFO:torchsnapshot.scheduler:   0            0            0            8           16            11.28          20.73/32.00               8.27
INFO:torchsnapshot.scheduler:   2            0            0            0           10             5.01          27.00/32.00              14.53
INFO:torchsnapshot.scheduler:   7            0            0            0            6             3.01          29.00/32.00              16.53
INFO:torchsnapshot.scheduler:   4            0            0            2           16             8.78          23.23/32.00              10.77
INFO:torchsnapshot.scheduler:   6            0            0            2           16             8.78          23.23/32.00              10.77
INFO:torchsnapshot.scheduler:   0            0            0            2           16             8.78          23.23/32.00              10.77
INFO:torchsnapshot.scheduler:   5            0            0            0           12             5.54          26.47/32.00              14.00
INFO:torchsnapshot.scheduler:   1            0            0            0            5             2.51          29.50/32.00              17.03
INFO:torchsnapshot.scheduler:   2            0            0            0            5             2.51          29.50/32.00              17.03
INFO:torchsnapshot.scheduler:   4            0            0            0           12             6.01          26.00/32.00              13.53
INFO:torchsnapshot.scheduler:   6            0            0            0           12             5.78          26.23/32.00              13.77
INFO:torchsnapshot.scheduler:   5            0            0            0            6             3.01          29.00/32.00              16.53
INFO:torchsnapshot.scheduler:   0            0            0            0           12             5.78          26.23/32.00              13.77
INFO:torchsnapshot.scheduler:   3            0            0            2           16             8.54          23.47/32.00              11.00
INFO:torchsnapshot.scheduler:   4            0            0            0            6             3.01          29.00/32.00              16.53
INFO:torchsnapshot.scheduler:   6            0            0            0            6             3.01          29.00/32.00              16.53
INFO:torchsnapshot.scheduler:   3            0            0            0           12             5.78          26.23/32.00              13.77
INFO:torchsnapshot.scheduler:   0            0            0            0            6             3.01          29.00/32.00              16.53
INFO:torchsnapshot.scheduler:   7            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 7 completed writing in 76.95 seconds (throughput 259.90MB/s) -----------------------
INFO:torchsnapshot.scheduler:   3            0            0            0            6             3.01          29.00/32.00              16.53
INFO:torchsnapshot.scheduler:   0            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 0 completed writing in 81.19 seconds (throughput 246.33MB/s) -----------------------
INFO:torchsnapshot.scheduler:   5            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 5 completed writing in 81.26 seconds (throughput 246.13MB/s) -----------------------
INFO:torchsnapshot.scheduler:   1            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 1 completed writing in 81.27 seconds (throughput 246.11MB/s) -----------------------
INFO:torchsnapshot.scheduler:   4            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 4 completed writing in 81.41 seconds (throughput 245.66MB/s) -----------------------
INFO:torchsnapshot.scheduler:   2            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 2 completed writing in 81.55 seconds (throughput 245.26MB/s) -----------------------
INFO:torchsnapshot.scheduler:   6            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 6 completed writing in 82.23 seconds (throughput 243.23MB/s) -----------------------
INFO:torchsnapshot.scheduler:   3            0            0            0            0             0.01          32.00/32.00              19.53
INFO:torchsnapshot.scheduler:----------------------- Rank 3 completed writing in 82.71 seconds (throughput 241.81MB/s) -----------------------
```