### PR TITLE
Add runtime typecheck for AppState

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -11,6 +11,7 @@ import unittest
 
 import torch
 import torchsnapshot
+from torchsnapshot import Snapshot
 from torchsnapshot.test_utils import assert_state_dict_eq, check_state_dict_eq
 
 
@@ -72,3 +73,13 @@ class SnapshotTest(unittest.TestCase):
             snapshot.restore({"optim": optim})
 
         assert_state_dict_eq(self, optim.state_dict(), expected)
+
+    def test_invalid_app_state(self) -> None:
+        not_stateful = 1
+        app_state = {"optim": not_stateful}
+
+        with tempfile.TemporaryDirectory() as path:
+            self.assertRaises(TypeError, torchsnapshot.Snapshot.take, path, app_state)
+
+            snapshot = Snapshot(path)
+            self.assertRaises(TypeError, snapshot.restore, app_state)


### PR DESCRIPTION
Summary:
I am fairly new to type checking so please give feedback.

Currently validation is added in public entry points and they should be mostly stable as the entry points are quite few so we don't worry about having to add more of these _validate_app_state() calls.

Reviewed By: ananthsub

Differential Revision: D39117667

