### PR TITLE
A typing clean up for event_loop

### DIFF
--- a/torchsnapshot/scheduler.py
+++ b/torchsnapshot/scheduler.py
@@ -342,10 +342,8 @@ def sync_execute_write_reqs(
     storage: StoragePlugin,
     memory_budget_bytes: int,
     rank: int,
-    event_loop: Optional[asyncio.AbstractEventLoop] = None,
+    event_loop: asyncio.AbstractEventLoop,
 ) -> PendingIOWork:
-    if event_loop is None:
-        event_loop = asyncio.new_event_loop()
     return event_loop.run_until_complete(
         execute_write_reqs(
             write_reqs=write_reqs,


### PR DESCRIPTION
Summary:
None checking seems redundant

This method is only used by _take_impl() in Snapshot.take(), where event_loop is always specified.

Differential Revision: D39197777

