### PR TITLE
Promote model weights to model dtype

### DIFF
--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -337,7 +337,7 @@ class TensorBufferStager(BufferStager):
     _custom_tensor_prepare_func: Callable[[str, torch.Tensor, bool], torch.Tensor]) -> None:
         self.tensor = tensor
         self.entry = entry
-        self._custom_tensor_prepare_func = custom_tensor_prepare_func
+        self._custom_tensor_prepare_func = _custom_tensor_prepare_func
 
     async def stage_buffer(self, executor: Optional[Executor] = None) -> BufferType:
         self.tensor = self._custom_tensor_prepare_func(self.entry.location, self.tensor, tracing=False)

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -99,7 +99,7 @@ class ChunkedTensorIOPreparer:
         tensor: torch.Tensor, chunk: Union[Shard, Chunk]
     ) -> torch.Tensor:
         # for 0-d case, reshape to 1-d
-        result = tensor.view(-1) if tensor.ndim == 0 else tensor_chunk_sizes
+        result = tensor.view(-1) if tensor.ndim == 0 else tensor
 
         for d in range(len(chunk.sizes)):
             result = result.narrow(d, chunk.offsets[d], chunk.sizes[d])

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -190,7 +190,7 @@ class ShardedTensorIOPreparer:
         cls,
         storage_path: str,
         obj: ShardedTensor,
-        custom_tensor_prepare_func: Callable,
+        custom_tensor_prepare_func: Callable[[str, torch.Tensor, bool], torch.Tensor],
     ) -> Tuple[ShardedTensorEntry, List[WriteReq]]:
         shards = []
         write_reqs = []
@@ -336,7 +336,7 @@ def tensor_to_cpu(tensor: torch.Tensor) -> torch.Tensor:
 
 class TensorBufferStager(BufferStager):
     def __init__(self, tensor: torch.Tensor, entry: TensorEntry,
-    custom_tensor_prepare_func: Callable) -> None:
+    custom_tensor_prepare_func: Callable[[str, torch.Tensor, bool], torch.Tensor]) -> None:
         self.tensor = tensor
         self.entry = entry
         self.custom_tensor_prepare_func = custom_tensor_prepare_func
@@ -430,7 +430,7 @@ class TensorIOPreparer:
     @staticmethod
     def prepare_write(
         storage_path: str, tensor: torch.Tensor,
-        custom_tensor_prepare_func: Callable,
+        custom_tensor_prepare_func: Callable[[str, torch.Tensor, bool], torch.Tensor],
     ) -> Tuple[TensorEntry, List[WriteReq]]:
 
         proc_tensor = custom_tensor_prepare_func(storage_path, tensor, tracing=True)
@@ -597,7 +597,7 @@ def prepare_write(
     logical_path: str,
     rank: int,
     replicated: bool,
-    custom_tensor_prepare_func: Callable,
+    custom_tensor_prepare_func: Callable[[str, torch.Tensor, bool], torch.Tensor],
 ) -> Tuple[Entry, List[WriteReq]]:
     """
     Prepare write for an object.

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -282,8 +282,6 @@ class ShardedTensorIOPreparer:
 
 @torch.jit.script
 def tensor_copy(dst: torch.Tensor, src: torch.Tensor) -> None:
-    if src.dtype == torch.qint8:
-      src = torch.dequantize(src)
     dst.detach().copy_(src)  # pragma: no cover
 
 

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -405,7 +405,6 @@ class TensorBufferConsumer(BufferConsumer):
     ) -> None:
         loaded = self.deserialize_tensor(buf=buf, entry=self.entry)
         if executor is not None:
-            print('consumer', self.tensor.shape, self.tensor.dtype)
             await asyncio.get_running_loop().run_in_executor(
                 executor, tensor_copy, self.tensor, loaded
             )

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -446,7 +446,7 @@ class TensorIOPreparer:
             replicated=False,
         )
         # stage the actual tensor, not processed tensor
-        buffer_stager = TensorBufferStager(tensor=tensor, entry=entry, _custom_tensor_prepare_func=custom_tensor_prepare_func)
+        buffer_stager = TensorBufferStager(tensor=tensor, entry=entry, _custom_tensor_prepare_func=_custom_tensor_prepare_func)
         return entry, [WriteReq(path=storage_path, buffer_stager=buffer_stager)]
 
     @classmethod

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -213,7 +213,7 @@ class ShardedTensorIOPreparer:
                 suffix = "_".join(str(i) for i in offsets)
                 entry, tensor_write_reqs = TensorIOPreparer.prepare_write(
                     storage_path=f"{storage_path}_{suffix}", tensor=tensor,
-                    _custom_tensor_prepare_func=custom_tensor_prepare_func
+                    _custom_tensor_prepare_func=_custom_tensor_prepare_func
                 )
                 write_reqs += tensor_write_reqs
 

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -176,6 +176,7 @@ class Snapshot:
         app_state: AppState,
         pg: Optional[dist.ProcessGroup] = None,
         replicated: Optional[List[str]] = None,
+        quantize: Optional[Tuple[int]] = None,
     ) -> "Snapshot":
         """
         Take a snapshot from the program state.
@@ -210,6 +211,7 @@ class Snapshot:
             pg_wrapper=PGWrapper(pg),
             storage=storage,
             event_loop=event_loop,
+            quantize=quantize,
         )
         pending_io_work.sync_complete(event_loop=event_loop)
 
@@ -235,6 +237,7 @@ class Snapshot:
         app_state: AppState,
         pg: Optional[dist.ProcessGroup] = None,
         replicated: Optional[List[str]] = None,
+        quantize: Optional[Tuple[int]] = None,
     ) -> "PendingSnapshot":
         """
         Asynchronously take a snapshot from the program state.
@@ -277,6 +280,7 @@ class Snapshot:
             pg_wrapper=PGWrapper(pg),
             storage=storage,
             event_loop=event_loop,
+            quantize=quantize,
         )
         # PendingSnapshot is responsible for closing `storage` and `event_loop`
         return PendingSnapshot(
@@ -297,6 +301,7 @@ class Snapshot:
         pg_wrapper: PGWrapper,
         storage: StoragePlugin,
         event_loop: asyncio.AbstractEventLoop,
+        quantize: Optional[Tuple[int]] = None,
     ) -> Tuple[PendingIOWork, SnapshotMetadata]:
         # TODO: validate app_state
 
@@ -386,6 +391,7 @@ class Snapshot:
                 logical_path=logical_path,
                 rank=pg_wrapper.get_rank(),
                 replicated=logical_path in replicated_set,
+                quantize=quantize,
             )
             object_entries[logical_path] = entry
             write_reqs.extend(item_write_reqs)

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -176,7 +176,7 @@ class Snapshot:
         app_state: AppState,
         pg: Optional[dist.ProcessGroup] = None,
         replicated: Optional[List[str]] = None,
-        custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
+        _custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
     ) -> "Snapshot":
         """
         Take a snapshot from the program state.
@@ -198,8 +198,8 @@ class Snapshot:
         torch._C._log_api_usage_once("torchsnapshot.Snapshot.take")
         event_loop = asyncio.new_event_loop()
         pg_wrapper = PGWrapper(pg=pg)
-        if not custom_tensor_prepare_func:
-            custom_tensor_prepare_func = lambda path, tensor, tracing : tensor
+        if not _custom_tensor_prepare_func:
+            _custom_tensor_prepare_func = lambda path, tensor, tracing : tensor
 
 
         path, replicated = cls._coalesce_path_and_replicated(
@@ -215,7 +215,7 @@ class Snapshot:
             pg_wrapper=PGWrapper(pg),
             storage=storage,
             event_loop=event_loop,
-            custom_tensor_prepare_func=custom_tensor_prepare_func,
+            _custom_tensor_prepare_func=custom_tensor_prepare_func,
         )
         pending_io_work.sync_complete(event_loop=event_loop)
 
@@ -241,7 +241,7 @@ class Snapshot:
         app_state: AppState,
         pg: Optional[dist.ProcessGroup] = None,
         replicated: Optional[List[str]] = None,
-        custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
+        _custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
     ) -> "PendingSnapshot":
         """
         Asynchronously take a snapshot from the program state.
@@ -278,8 +278,8 @@ class Snapshot:
             url_path=path, event_loop=event_loop
         )
 
-        if not custom_tensor_prepare_func:
-            custom_tensor_prepare_func = lambda path, tensor, tracing : tensor
+        if not _custom_tensor_prepare_func:
+            _custom_tensor_prepare_func = lambda path, tensor, tracing : tensor
 
         pending_io_work, metadata = cls._take_impl(
             path=path,
@@ -288,7 +288,7 @@ class Snapshot:
             pg_wrapper=PGWrapper(pg),
             storage=storage,
             event_loop=event_loop,
-            custom_tensor_prepare_func=custom_tensor_prepare_func,
+            _custom_tensor_prepare_func=custom_tensor_prepare_func,
         )
         # PendingSnapshot is responsible for closing `storage` and `event_loop`
         return PendingSnapshot(
@@ -309,7 +309,7 @@ class Snapshot:
         pg_wrapper: PGWrapper,
         storage: StoragePlugin,
         event_loop: asyncio.AbstractEventLoop,
-        custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
+        _custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
     ) -> Tuple[PendingIOWork, SnapshotMetadata]:
         # TODO: validate app_state
 
@@ -399,7 +399,7 @@ class Snapshot:
                 logical_path=logical_path,
                 rank=pg_wrapper.get_rank(),
                 replicated=logical_path in replicated_set,
-                custom_tensor_prepare_func=custom_tensor_prepare_func,
+                _custom_tensor_prepare_func=custom_tensor_prepare_func,
             )
             object_entries[logical_path] = entry
             write_reqs.extend(item_write_reqs)

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -215,7 +215,7 @@ class Snapshot:
             pg_wrapper=PGWrapper(pg),
             storage=storage,
             event_loop=event_loop,
-            _custom_tensor_prepare_func=custom_tensor_prepare_func,
+            _custom_tensor_prepare_func=_custom_tensor_prepare_func,
         )
         pending_io_work.sync_complete(event_loop=event_loop)
 
@@ -288,7 +288,7 @@ class Snapshot:
             pg_wrapper=PGWrapper(pg),
             storage=storage,
             event_loop=event_loop,
-            _custom_tensor_prepare_func=custom_tensor_prepare_func,
+            _custom_tensor_prepare_func=_custom_tensor_prepare_func,
         )
         # PendingSnapshot is responsible for closing `storage` and `event_loop`
         return PendingSnapshot(

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -386,6 +386,7 @@ class Snapshot:
                     pg_wrapper.get_rank(),
                     logical_path in replicated_set,
                 ),
+                _custom_tensor_prepare_func=_custom_tensor_prepare_func,
                 tensor=flattened[logical_path],
                 chunking_instruction=chunking_instructions[logical_path],
             )

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -399,7 +399,7 @@ class Snapshot:
                 logical_path=logical_path,
                 rank=pg_wrapper.get_rank(),
                 replicated=logical_path in replicated_set,
-                _custom_tensor_prepare_func=custom_tensor_prepare_func,
+                _custom_tensor_prepare_func=_custom_tensor_prepare_func,
             )
             object_entries[logical_path] = entry
             write_reqs.extend(item_write_reqs)

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -657,6 +657,9 @@ class Snapshot:
         mnfst, flattened = flatten(state_dict, prefix=stateful_key)
         del state_dict
 
+        #breakpoint()
+        print('flattened', flattened)
+        print('available_entries', available_entries)
         read_reqs: List[ReadReq] = []
         for logical_path, obj in flattened.items():
             if logical_path not in available_entries:

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -176,7 +176,7 @@ class Snapshot:
         app_state: AppState,
         pg: Optional[dist.ProcessGroup] = None,
         replicated: Optional[List[str]] = None,
-        custom_tensor_prepare_func: Optional[Callable] = None,
+        custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
     ) -> "Snapshot":
         """
         Take a snapshot from the program state.
@@ -241,7 +241,7 @@ class Snapshot:
         app_state: AppState,
         pg: Optional[dist.ProcessGroup] = None,
         replicated: Optional[List[str]] = None,
-        custom_tensor_prepare_func: Optional[Callable] = None,
+        custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
     ) -> "PendingSnapshot":
         """
         Asynchronously take a snapshot from the program state.
@@ -309,7 +309,7 @@ class Snapshot:
         pg_wrapper: PGWrapper,
         storage: StoragePlugin,
         event_loop: asyncio.AbstractEventLoop,
-        custom_tensor_prepare_func: Callable,
+        custom_tensor_prepare_func: Optional[Callable[[str, torch.Tensor, bool], torch.Tensor]] = None,
     ) -> Tuple[PendingIOWork, SnapshotMetadata]:
         # TODO: validate app_state
 


### PR DESCRIPTION
To control what the restored model dtypes are, we allow restoration to promote dtypes upwards in precision to match the dtype of the constructed model.

e.g.
If snapshot saved a quantized version, and model created was fp32, it will restore as fp32
If snapshot saved a quantized version, and model created is quantized, it will restore as quantized


however this does not work with the following code (run with `torchrun` on rank = 2)

```
import os
from pathlib import Path
from typing import List, Optional

import torch
from torch import distributed as dist
from torch.distributed.elastic.multiprocessing.errors import record
from torch.utils.data import IterableDataset
from torchrec.datasets.criteo import DEFAULT_CAT_NAMES, DEFAULT_INT_NAMES
from torchrec.datasets.random import RandomRecDataset
from torchrec.distributed import TrainPipelineSparseDist
from torchrec.distributed.model_parallel import DistributedModelParallel
from torchrec.models.dlrm import DLRM, DLRMTrain
from torchrec.modules.embedding_configs import DataType, EmbeddingBagConfig
from torchrec.modules.embedding_modules import EmbeddingBagCollection
from torchrec.modules.fused_embedding_modules import fuse_embedding_optimizer
from torchrec.optim.keyed import KeyedOptimizerWrapper
from torchrec.optim.rowwise_adagrad import RowWiseAdagrad
from torchsnapshot import Snapshot
import torchrec.quant as trec_quant

from torch.distributed._shard.sharding_spec import ChunkShardingSpec
import torchsnapshot
from torchsnapshot.io_preparer import TensorIOPreparer
from torchsnapshot.io_preparer import ShardedTensorIOPreparer
from torchsnapshot.manifest import Shard, ShardedTensorEntry

import tempfile
import functools


def train(
    #num_embeddings: int = 10,
    num_embeddings: int = 1024,
    embedding_dim: int = 128,
    #embedding_dim: int = 8,
) -> None:
  device: torch.device = torch.device("cuda")
  backend = "gloo"
  dist.init_process_group(backend=backend)

  table_names = ["feature1", "feature2"]
  def gen_eb_configs(data_type):
    return [
      EmbeddingBagConfig(
        name=f"t_{feature_name}",
        embedding_dim=embedding_dim,
        num_embeddings=num_embeddings,
        feature_names=[feature_name],
        data_type=data_type,
      )
      for feature_name in table_names
    ]

  eb_configs = gen_eb_configs(DataType.FP32)
  original_ebc = torch.nn.Sequential(EmbeddingBagCollection(tables=eb_configs, device=torch.device('meta')))
  original_ebc = DistributedModelParallel(module=original_ebc, device=device)

  from torchrec.sparse.jagged_tensor import KeyedJaggedTensor
  features = KeyedJaggedTensor(
    keys=["feature1", "feature2"],
    values=torch.arange(num_embeddings).cuda(),
    lengths=torch.ones(num_embeddings).int().cuda(),
  )
  original_lookups = original_ebc(features).values()
  torch.testing.assert_close(original_ebc(features).values(), original_lookups)

  print('before save lookup', original_ebc(features).values()[0][:10])
  # this should be ~3.5 mb vs 14mb for unquantized
  # to generate unquantized, remove the monkeypatching on ShardedTensorIOPreparer
  #print(original_ebc.state_dict())
  weights = torch.cat(
    [
        torch.flatten(_tensor.local_tensor()) for _tensor in original_ebc.state_dict().values()
    ]
  )
  #weights = original_ebc.state_dict()['embedding_bags.t_feature1.weight'].local_tensor()
  weight_min, weight_max = torch.min(weights), torch.max(weights)
  scale = (weight_max - weight_min) / (63 - -64)
  zero_point = -64 - (weight_min / scale)
  print(scale, zero_point)

  # function that looks at the model path and decides if module should be quantized
  # in this simple example, everything has "embedding" in the path, so it's all getting quantized

  def to_quantize(path: str) -> bool:
    """ Returns `True` if `path` is a module that should be quantized.
    """
    return "embedding" in path

  # This part would be shoved into torchsnapshot as a utility
  def make_custom_tensor_prepare_func(to_quantize):
    quantized_dtype = torch.qint8
    def custom_tensor_prepare_func(path: str, tensor:torch.Tensor, tracing:bool=False):
        # in tracing mode, return a MetaTensor with correct dtype/size but do not allocate the memory
        # otherwise, perform the op
        if to_quantize(path):
          tensor = tensor.float()
          if tracing:
            return torch.tensor(tensor, dtype=quantized_dtype, device='meta')
          else:
            observer = torch.quantization.observer.MinMaxObserver(dtype=quantized_dtype)
            observer(tensor)
            scale, zero_point = observer.calculate_qparams()
            # TODO: Do quantization ourselves.
            return torch.quantize_per_tensor(tensor, scale.cuda(), zero_point.cuda(), quantized_dtype)
        else:
          return tensor
    return custom_tensor_prepare_func

  import shutil
  shutil.rmtree('./base', ignore_errors=True)
  shutil.rmtree('./quant', ignore_errors=True)

  base_snapshot = Snapshot.take(path="./base", app_state={"model": original_ebc})
  quant_snapshot = Snapshot.take(
    path="./quant", app_state={"model": original_ebc},
    _custom_tensor_prepare_func=make_custom_tensor_prepare_func(to_quantize))

  ebc = torch.nn.Sequential(EmbeddingBagCollection(tables=eb_configs, device=torch.device('meta')))
  ebc = DistributedModelParallel(module=ebc, device=device)

  try:
    torch.testing.assert_close(ebc(features).values(), original_lookups)
  except AssertionError:
    pass

  from torchrec.inference.modules import quantize_embeddings
  import torchrec.quant as trec_quant
  from typing import Dict
  import torch.quantization as quant

  q_eb_configs = gen_eb_configs(DataType.FP32)
  qebc = torch.nn.Sequential(EmbeddingBagCollection(tables=q_eb_configs, device=torch.device('meta')))
  print('!!!! before', qebc.state_dict())
  qebc = quantize_embeddings(qebc, dtype=torch.qint8, inplace=True)
  print('!!!! after quantize', {key: value.dtype for key, value in qebc.state_dict().items()})
  qebc = DistributedModelParallel(module=qebc, device=device)

  base_snapshot.restore(app_state={"model": ebc})
  quant_snapshot.restore(app_state={"model": qebc})

  print('!!!! after restore', {key: value.dtype for key, value in qebc.state_dict().items()})

  torch.testing.assert_close(original_ebc(features).values(), original_lookups)
  torch.testing.assert_close(qebc(features).values(), original_lookups, rtol=1e-3, atol=1e-3)
  print("*******************")
  print("*******************")

  from pathlib import Path
  base_size = sum(f.stat().st_size for f in Path('./base').glob('**/*') if f.is_file())
  quant_size = sum(f.stat().st_size for f in Path('./quant').glob('**/*') if f.is_file())
  print(base_size)
  print(quant_size)
  print(quant_size / base_size)


if __name__ == "__main__":
    main()
```

```
  File "/opt/ee/python/3.8/lib/python3.8/site-packages/torchsnapshot-0.0.3-py3.8.egg/torchsnapshot/snapshot.py", line 468, in restore
  File "/opt/ee/python/3.8/lib/python3.8/site-packages/torchsnapshot-0.0.3-py3.8.egg/torchsnapshot/snapshot.py", line 712, in _load_stateful
  File "/opt/ee/python/3.8/lib/python3.8/site-packages/torchsnapshot-0.0.3-py3.8.egg/torchsnapshot/io_preparer.py", line 706, in prepare_read
  File "/opt/ee/python/3.8/lib/python3.8/site-packages/torchsnapshot-0.0.3-py3.8.egg/torchsnapshot/io_preparer.py", line 271, in prepare_read
  File "/opt/ee/python/3.8/lib/python3.8/site-packages/torchsnapshot-0.0.3-py3.8.egg/torchsnapshot/torch_dist_checkpoint/resharding.py", line 152, in prepare_sharded_tensor_read
AttributeError: 'Tensor' object has no attribute 'local_shards'
```

