### PR TITLE
Cleanup PT-D imports

### DIFF
--- a/examples/torchrec/main.py
+++ b/examples/torchrec/main.py
@@ -96,7 +96,6 @@ def get_rowwise_sharding_plan(
     )
     pg = dist.group.WORLD
     assert pg is not None
-    # pyre-fixme[6]: For 3rd param expected `ProcessGroup` but got `ProcessGroup`.
     return planner.collective_plan(module=module, sharders=SHARDERS, pg=pg)
 
 

--- a/tests/test_dist_store.py
+++ b/tests/test_dist_store.py
@@ -21,8 +21,6 @@ class DistStoreTest(unittest.TestCase):
     def _test_create_store(init_pg: bool) -> None:
         if init_pg:
             dist.init_process_group(backend="gloo")
-        # pyre-fixme[6]: For 1st param expected `Optional[dist.ProcessGroup]` but
-        #  got `Optional[_distributed_c10d.ProcessGroup]`.
         pg_wrapper = PGWrapper(pg=dist.group.WORLD)
         store = create_store(pg_wrapper=pg_wrapper)
 
@@ -39,8 +37,6 @@ class DistStoreTest(unittest.TestCase):
 
     @staticmethod
     def _test_linear_barrier() -> None:
-        # pyre-fixme[6]: For 1st param expected `Optional[dist.ProcessGroup]` but
-        #  got `Optional[_distributed_c10d.ProcessGroup]`.
         pg_wrapper = PGWrapper(pg=dist.group.WORLD)
         store = get_or_create_store(pg_wrapper=pg_wrapper)
 
@@ -62,8 +58,6 @@ class DistStoreTest(unittest.TestCase):
     @staticmethod
     def _test_linear_barrier_timeout() -> None:
         dist.init_process_group(backend="gloo")
-        # pyre-fixme[6]: For 1st param expected `Optional[dist.ProcessGroup]` but
-        #  got `Optional[_distributed_c10d.ProcessGroup]`.
         pg_wrapper = PGWrapper(pg=dist.group.WORLD)
         rank = pg_wrapper.get_rank()
         store = get_or_create_store(pg_wrapper=pg_wrapper)
@@ -129,8 +123,6 @@ class DistStoreTest(unittest.TestCase):
     @staticmethod
     def _test_linear_barrier_error() -> None:
         dist.init_process_group(backend="gloo")
-        # pyre-fixme[6]: For 1st param expected `Optional[dist.ProcessGroup]` but
-        #  got `Optional[_distributed_c10d.ProcessGroup]`.
         pg_wrapper = PGWrapper(pg=dist.group.WORLD)
         rank = pg_wrapper.get_rank()
         store = get_or_create_store(pg_wrapper=pg_wrapper)


### PR DESCRIPTION
Summary:
The flow logic around torch.dist imports results in large number of pyre errors; would be preferable to just raise on importing as opposed to silently fail to import bindings.

Cons: Some percentage (MacOS?) of users may have notebooks that imports pytorch.distributed, although would think small, since any attempt to call parts of the library would just fail...

fb:
TODO: assuming ok, will remove the 10's-100's of unused pyre ignores no longer required.

Differential Revision: D39842273

