### PR TITLE
Update unit test workflow's GITHUB_TOKEN permission

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -11,6 +11,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Check out repo
         uses: actions/checkout@v2


### PR DESCRIPTION
This is a preparation step for configuring aws-actions/configure-aws-credentials@v1.

https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
