### PR TITLE
Some test fixes and improvements

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -1,4 +1,4 @@
-name: unit test
+name: Unit tests
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint
     permissions:
       id-token: write
       contents: read
@@ -38,6 +38,6 @@ jobs:
         run: |
           set -eux
           conda activate test
-          pytest --cov=. --cov-report xml tests -vv
-      - name: Upload Coverage to Codecov
+          pytest --timeout=300 --cov=. --cov-report xml tests -vv -rs
+      - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/unit_test_gpu.yaml
+++ b/.github/workflows/unit_test_gpu.yaml
@@ -1,4 +1,4 @@
-name: unit test
+name: Unit tests (GPU)
 
 on:
   push:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [linux.p3.8xlarge.nvidia.gpu]
+        os: [linux.8xlarge.nvidia.gpu]
         python-version: [3.8]
         cuda-tag: ["cu11"]
     steps:
@@ -59,6 +59,12 @@ jobs:
           set -eux
           conda activate test
           pip install --pre torch -f https://download.pytorch.org/whl/nightly/cu113/torch_nightly.html
+          pip install torchrec-nightly
+
+          # Use stable fbgemm-gpu
+          pip uninstall -y fbgemm-gpu-nightly
+          pip install fbgemm-gpu
+
           pip install -r requirements.txt
           pip install -r dev-requirements.txt
           pip install --no-build-isolation -e ".[dev]"
@@ -67,6 +73,6 @@ jobs:
         run: |
           set -eux
           conda activate test
-          pytest --cov=. --cov-report xml tests/gpu_tests -vv
-      - name: Upload Coverage to Codecov
+          pytest --cov=. --cov-report xml tests/gpu_tests -vv -rs
+      - name: Upload coverage to codecov
         uses: codecov/codecov-action@v2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
+aiobotocore
 numpy
 pre-commit
 pytest
-pytest-cov
 pytest-asyncio
---find-links=https://download.pytorch.org/whl/nightly/torchrec_nightly/index.html
-torchrec_nightly
+pytest-cov
+pytest-timeout

--- a/tests/gpu_tests/test_torchrec.py
+++ b/tests/gpu_tests/test_torchrec.py
@@ -13,16 +13,18 @@ import tempfile
 import unittest
 from typing import List
 
+import pytest
+
 import torch
 import torch.distributed as dist
 import torch.distributed.launcher as pet
 
-import torchsnapshot
-
 try:
     import torchrec
-except Exception:
-    raise unittest.SkipTest("torchrec not found")
+except Exception as e:
+    pytest.skip(f"Failed to import torchrec due to {e}", allow_module_level=True)
+
+import torchsnapshot
 
 from fbgemm_gpu.split_embedding_configs import EmbOptimType
 from torchrec.distributed import ModuleSharder
@@ -234,7 +236,7 @@ class TorchrecTest(unittest.TestCase):
         for max_shard_sz_bytes in [16 * 1024 * 1024, 16 * 1024 * 1024 - 1]:
             with self.subTest(max_shard_sz_bytes=max_shard_sz_bytes):
                 with tempfile.TemporaryDirectory() as path:
-                    lc = get_pet_launch_config(nproc=4)
+                    lc = get_pet_launch_config(nproc=2)
                     pet.elastic_launch(lc, entrypoint=self._test_take_restore)(
                         path, max_shard_sz_bytes, False
                     )
@@ -245,7 +247,7 @@ class TorchrecTest(unittest.TestCase):
         for max_shard_sz_bytes in [16 * 1024 * 1024, 16 * 1024 * 1024 - 1]:
             with self.subTest(max_shard_sz_bytes=max_shard_sz_bytes):
                 with tempfile.TemporaryDirectory() as path:
-                    lc = get_pet_launch_config(nproc=4)
+                    lc = get_pet_launch_config(nproc=2)
                     pet.elastic_launch(lc, entrypoint=self._test_take_restore)(
                         path, max_shard_sz_bytes, True
                     )


### PR DESCRIPTION
- Fix torchrec tests by switching to fbgemm-gpu stable
- Switch GPU tests to use linux.8xlarge.nvidia.gpu which has much better availability
- Show skipped test modules and reason
- Add test runner timeout
- S3 tests unittest -> pytest
- [Failed to do] enable AWS tests on CI. For some reason S3 access caused hang randomly