### PR TITLE
Replace Python Dumper and Loader with C counterparts to speed up metadata serialization

### DIFF
--- a/torchsnapshot/manifest.py
+++ b/torchsnapshot/manifest.py
@@ -15,6 +15,11 @@ from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import yaml
 
+try:
+    from yaml import CSafeDumper as Dumper, CSafeLoader as Loader
+except ImportError:
+    from yaml import Dumper, Loader
+
 
 @dataclass
 class Entry:
@@ -237,11 +242,11 @@ class SnapshotMetadata:
     manifest: Manifest
 
     def to_yaml(self) -> str:
-        return yaml.dump(asdict(self), sort_keys=False)
+        return yaml.dump(asdict(self), sort_keys=False, Dumper=Dumper)
 
     @classmethod
     def from_yaml(cls, yaml_str: str) -> "SnapshotMetadata":
-        d = yaml.safe_load(yaml_str)
+        d = yaml.load(yaml_str, Loader=Loader)
         manifest: Manifest = {}
         for path, entry in d["manifest"].items():
             type_name = entry["type"]


### PR DESCRIPTION
Summary: As discussed offline, metadata serialization currently takes up a significant amount of time when we checkpoint small models. We swap out the default Python implementations of the `Dumper` and `Loader` with their C versions in `PyYAML` to speed it up. For more information, please see [the PyYAML documentation](https://pyyaml.org/wiki/PyYAMLDocumentation).

Reviewed By: yifuwang

Differential Revision: D39990527

