### PR TITLE
Fix setup.py and avoid circular dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ importlib-metadata
 psutil
 typing-extensions
 PyYAML
+torch

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,10 @@ from datetime import date
 from typing import List
 
 from setuptools import find_packages, setup
-from torchsnapshot import __version__
 
+# using exec_file instead of the import to avoid having to install dependencies
+# when building the wheel
+exec(open('torchsnapshot/version.py').read())
 
 def current_path(file_name: str) -> str:
     return os.path.abspath(os.path.join(__file__, os.path.pardir, file_name))


### PR DESCRIPTION
Summary:
Newer versions of Pip require specifying all dependencies in config disallowing reading from the current directory. So we need to add `torch` and also to read `__version__` without relying in the package.

Test plan:
Tested with `pip 22.2.2`: `pip install .` was failing before and now succeeds.
