### PR TITLE
Some modifications to quantized tensor serializers

### DIFF
--- a/tests/test_ddp_replication_glob.py
+++ b/tests/test_ddp_replication_glob.py
@@ -5,80 +5,53 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
-import tempfile
-import unittest
+from pathlib import Path
 from typing import List, Optional
+
+import pytest
 
 import torch
 import torch.distributed as dist
-import torch.distributed.launcher as pet
-import torchsnapshot
 from torch.nn.parallel import DistributedDataParallel as DDP
-from torchsnapshot.manifest import is_replicated, SnapshotMetadata
-from torchsnapshot.snapshot import SNAPSHOT_METADATA_FNAME
+from torchsnapshot import Snapshot
+from torchsnapshot.manifest import is_replicated
 from torchsnapshot.stateful import AppState
-from torchsnapshot.test_utils import get_pet_launch_config
+from torchsnapshot.test_utils import run_with_pet
 
 
-class ReplicationDDPGlobTest(unittest.TestCase):
-    @staticmethod
-    def _worker(path: str, replication_globs: List[List[str]]) -> None:
-        dist.init_process_group(backend="gloo")
-        app_state: AppState = {
-            "ddp": DDP(torch.nn.Linear(4, 3)),
-            "nonddp": torch.nn.Linear(3, 2),
-        }
-        torchsnapshot.Snapshot.take(
-            path=path,
-            app_state=app_state,
-            replicated=replication_globs[dist.get_rank()],
-        )
-
-    def _test_helper(
-        self,
-        nproc: int,
-        replication_globs: List[Optional[List[str]]],
-        expected_replicated_paths: List[str],
-    ) -> None:
-        """
-        Verify whether the supplied replication globs result in expected
-        replicated paths.
-        """
-        lc = get_pet_launch_config(nproc=nproc)
-        with tempfile.TemporaryDirectory() as path:
-            pet.elastic_launch(lc, entrypoint=self._worker)(path, replication_globs)
-            with open(os.path.join(path, SNAPSHOT_METADATA_FNAME)) as f:
-                metadata = SnapshotMetadata.from_yaml(f.read())
-        replicated_paths = [
-            path for path in metadata.manifest if is_replicated(metadata.manifest[path])
-        ]
-        self.assertSetEqual(set(replicated_paths), set(expected_replicated_paths))
-
-    def test_only_ddp_replicated(self) -> None:
-        expected_replicated_paths: List[str] = [
-            "0/ddp/module.weight",
-            "0/ddp/module.bias",
-            "1/ddp/module.weight",
-            "1/ddp/module.bias",
-        ]
-
-        replication_globs: List[Optional[List[str]]] = [[], []]
-        self._test_helper(2, replication_globs, expected_replicated_paths)
-
-        replication_globs: List[Optional[List[str]]] = [None, None]
-        self._test_helper(2, replication_globs, expected_replicated_paths)
-
-    def test_all_replicated(self) -> None:
-        replication_globs: List[Optional[List[str]]] = [["**"], ["**"]]
-        expected_replicated_paths: List[str] = [
-            "0/ddp/module.weight",
-            "0/ddp/module.bias",
-            "1/ddp/module.weight",
-            "1/ddp/module.bias",
-            "0/nonddp/weight",
-            "0/nonddp/bias",
-            "1/nonddp/weight",
-            "1/nonddp/bias",
-        ]
-        self._test_helper(2, replication_globs, expected_replicated_paths)
+@pytest.mark.parametrize(
+    "replication_globs, expected_replicated_paths",
+    [
+        ([], ["0/ddp/module.weight", "0/ddp/module.bias"]),
+        (None, ["0/ddp/module.weight", "0/ddp/module.bias"]),
+        (
+            ["**"],
+            [
+                "0/ddp/module.weight",
+                "0/ddp/module.bias",
+                "0/nonddp/weight",
+                "0/nonddp/bias",
+            ],
+        ),
+    ],
+)
+@run_with_pet(nproc=2)
+def test_ddp_replication_glob(
+    replication_globs: Optional[List[str]],
+    expected_replicated_paths: List[str],
+    tmp_path: Path,
+) -> None:
+    dist.init_process_group(backend="gloo")
+    app_state: AppState = {
+        "ddp": DDP(torch.nn.Linear(4, 3)),
+        "nonddp": torch.nn.Linear(3, 2),
+    }
+    snapshot = Snapshot.take(
+        path=str(tmp_path),
+        app_state=app_state,
+        replicated=replication_globs,
+    )
+    replicated_paths = [
+        path for path, entry in snapshot.get_manifest().items() if is_replicated(entry)
+    ]
+    assert set(replicated_paths) == set(expected_replicated_paths)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -5,12 +5,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import unittest
+from typing import Dict
+
+import pytest
 
 from torchsnapshot.manifest import (
     ChunkedTensorEntry,
     DictEntry,
+    Entry,
     get_available_entries,
+    is_container_entry,
+    is_replicated,
     ObjectEntry,
     Shard,
     ShardedTensorEntry,
@@ -18,7 +23,8 @@ from torchsnapshot.manifest import (
     TensorEntry,
 )
 
-_MANIFEST = {
+_WORLD_SIZE = 2
+_MANIFEST_0: Dict[str, Entry] = {
     "0/foo": DictEntry(
         keys=["bar", "baz", "qux", "quuux", "qux_chunked", "quux_chunked"]
     ),
@@ -205,302 +211,74 @@ _MANIFEST = {
     ),
 }
 
+# Same as _MANIFEST_0 expect that replicated entries only exist on rank 0
+_MANIFEST_1: Dict[str, Entry] = {
+    k: v
+    for k, v in _MANIFEST_0.items()
+    if not (k.startswith("1/") and is_replicated(v))
+}
 
-class ManifestTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.maxDiff = None
 
-    def test_yaml(self) -> None:
-        metadata = SnapshotMetadata(
-            version="0.0.0",
-            world_size=2,
-            manifest=_MANIFEST,
-        )
-        yaml_str = metadata.to_yaml()
-        loaded_metadata = SnapshotMetadata.from_yaml(yaml_str=yaml_str)
-        self.assertDictEqual(metadata.manifest, loaded_metadata.manifest)
+@pytest.mark.parametrize("manifest", [_MANIFEST_0, _MANIFEST_1])
+def test_manifest_yaml_serialization(manifest: Dict[str, Entry]) -> None:
+    metadata = SnapshotMetadata(
+        version="0.0.0",
+        world_size=_WORLD_SIZE,
+        manifest=manifest,
+    )
+    yaml_str = metadata.to_yaml()
+    loaded_metadata = SnapshotMetadata.from_yaml(yaml_str=yaml_str)
+    assert metadata.manifest == loaded_metadata.manifest
 
-    def test_load_with_same_world_size_rank_zero(self) -> None:
-        available_entries = get_available_entries(_MANIFEST, 0)
-        expected_available_entries = {
-            "foo/bar": ObjectEntry(
-                location="0/foo/bar",
-                serializer="torch_save",
-                obj_type="Bar",
-                replicated=False,
-            ),
-            "foo/baz": ObjectEntry(
-                location="replicated/foo/baz",
-                serializer="torch_save",
-                obj_type="Baz",
-                replicated=True,
-            ),
-            "foo/qux": ShardedTensorEntry(
-                shards=[
-                    Shard(
-                        offsets=[0, 0],
-                        sizes=[4, 4],
-                        tensor=TensorEntry(
-                            location="sharded/foo/qux.0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 8],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[4, 0],
-                        sizes=[4, 4],
-                        tensor=TensorEntry(
-                            location="sharded/foo/qux.1",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 8],
-                            replicated=False,
-                        ),
-                    ),
-                ]
-            ),
-            "foo/quux": TensorEntry(
-                location="0/foo/quux",
-                serializer="torch_save",
-                dtype="float32",
-                shape=[128, 128],
-                replicated=False,
-            ),
-            "foo/qux_chunked": ChunkedTensorEntry(
-                dtype="float32",
-                shape=[7, 10],
-                chunks=[
-                    Shard(
-                        offsets=[0, 0],
-                        sizes=[5, 10],
-                        tensor=TensorEntry(
-                            location="replicated/foo/qux_chunked_0_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[5, 10],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[5, 0],
-                        sizes=[2, 10],
-                        tensor=TensorEntry(
-                            location="replicated/foo/qux_chunked_5_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 10],
-                            replicated=False,
-                        ),
-                    ),
-                ],
-                replicated=True,
-            ),
-            "foo/quux_chunked": ChunkedTensorEntry(
-                dtype="float32",
-                shape=[100],
-                chunks=[
-                    Shard(
-                        offsets=[0],
-                        sizes=[50],
-                        tensor=TensorEntry(
-                            location="0/foo/qux_chunked_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[50],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[50],
-                        sizes=[50],
-                        tensor=TensorEntry(
-                            location="0/foo/qux_chunked_50",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[50],
-                            replicated=False,
-                        ),
-                    ),
-                ],
-                replicated=False,
-            ),
-        }
-        self.assertDictEqual(available_entries, expected_available_entries)
 
-    def test_load_with_same_world_size_rank_one(self) -> None:
-        available_entries = get_available_entries(_MANIFEST, 1)
-        expected_available_entries = {
-            "foo/bar": ObjectEntry(
-                location="1/foo/bar",
-                serializer="torch_save",
-                obj_type="Bar",
-                replicated=False,
-            ),
-            "foo/baz": ObjectEntry(
-                location="replicated/foo/baz",
-                serializer="torch_save",
-                obj_type="Baz",
-                replicated=True,
-            ),
-            "foo/qux": ShardedTensorEntry(
-                shards=[
-                    Shard(
-                        offsets=[0, 0],
-                        sizes=[4, 4],
-                        tensor=TensorEntry(
-                            location="sharded/foo/qux.0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 8],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[4, 0],
-                        sizes=[4, 4],
-                        tensor=TensorEntry(
-                            location="sharded/foo/qux.1",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 8],
-                            replicated=False,
-                        ),
-                    ),
-                ]
-            ),
-            "foo/quux": TensorEntry(
-                location="1/foo/quux",
-                serializer="torch_save",
-                dtype="float32",
-                shape=[128, 128],
-                replicated=False,
-            ),
-            "foo/qux_chunked": ChunkedTensorEntry(
-                dtype="float32",
-                shape=[7, 10],
-                chunks=[
-                    Shard(
-                        offsets=[0, 0],
-                        sizes=[5, 10],
-                        tensor=TensorEntry(
-                            location="replicated/foo/qux_chunked_0_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[5, 10],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[5, 0],
-                        sizes=[2, 10],
-                        tensor=TensorEntry(
-                            location="replicated/foo/qux_chunked_5_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 10],
-                            replicated=False,
-                        ),
-                    ),
-                ],
-                replicated=True,
-            ),
-            "foo/quux_chunked": ChunkedTensorEntry(
-                dtype="float32",
-                shape=[100],
-                chunks=[
-                    Shard(
-                        offsets=[0],
-                        sizes=[50],
-                        tensor=TensorEntry(
-                            location="1/foo/qux_chunked_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[50],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[50],
-                        sizes=[50],
-                        tensor=TensorEntry(
-                            location="1/foo/qux_chunked_50",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[50],
-                            replicated=False,
-                        ),
-                    ),
-                ],
-                replicated=False,
-            ),
-        }
-        self.assertDictEqual(available_entries, expected_available_entries)
+@pytest.mark.parametrize("manifest", [_MANIFEST_0, _MANIFEST_1])
+@pytest.mark.parametrize("rank", range(_WORLD_SIZE * 2))
+def test_get_available_entries(manifest: Dict[str, Entry], rank: int) -> None:
+    available_entries = get_available_entries(manifest, rank)
+    expected_available_entries = {}
+    for path, entry in manifest.items():
+        if is_container_entry(entry):
+            continue
+        local_path = "/".join(path.split("/")[1:])
+        if path.startswith(f"{rank}/") or is_replicated(entry):
+            expected_available_entries[local_path] = entry
 
-    def test_load_with_larger_world_size(self) -> None:
-        available_entries = get_available_entries(_MANIFEST, 42)
-        expected_available_entries = {
-            "foo/baz": ObjectEntry(
-                location="replicated/foo/baz",
-                serializer="torch_save",
-                obj_type="Baz",
-                replicated=True,
+    expected_available_entries["foo/qux"] = ShardedTensorEntry(
+        shards=[
+            Shard(
+                offsets=[0, 0],
+                sizes=[4, 4],
+                tensor=TensorEntry(
+                    location="sharded/foo/qux.0",
+                    serializer="torch_save",
+                    dtype="float32",
+                    shape=[2, 8],
+                    replicated=False,
+                ),
             ),
-            "foo/qux": ShardedTensorEntry(
-                shards=[
-                    Shard(
-                        offsets=[0, 0],
-                        sizes=[4, 4],
-                        tensor=TensorEntry(
-                            location="sharded/foo/qux.0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 8],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[4, 0],
-                        sizes=[4, 4],
-                        tensor=TensorEntry(
-                            location="sharded/foo/qux.1",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 8],
-                            replicated=False,
-                        ),
-                    ),
-                ]
+            Shard(
+                offsets=[4, 0],
+                sizes=[4, 4],
+                tensor=TensorEntry(
+                    location="sharded/foo/qux.1",
+                    serializer="torch_save",
+                    dtype="float32",
+                    shape=[2, 8],
+                    replicated=False,
+                ),
             ),
-            "foo/qux_chunked": ChunkedTensorEntry(
-                dtype="float32",
-                shape=[7, 10],
-                chunks=[
-                    Shard(
-                        offsets=[0, 0],
-                        sizes=[5, 10],
-                        tensor=TensorEntry(
-                            location="replicated/foo/qux_chunked_0_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[5, 10],
-                            replicated=False,
-                        ),
-                    ),
-                    Shard(
-                        offsets=[5, 0],
-                        sizes=[2, 10],
-                        tensor=TensorEntry(
-                            location="replicated/foo/qux_chunked_5_0",
-                            serializer="torch_save",
-                            dtype="float32",
-                            shape=[2, 10],
-                            replicated=False,
-                        ),
-                    ),
-                ],
-                replicated=True,
-            ),
-        }
-        self.assertDictEqual(available_entries, expected_available_entries)
+        ]
+    )
+    assert available_entries == expected_available_entries
+
+
+@pytest.mark.parametrize("rank", range(_WORLD_SIZE * 2))
+def test_replicated_entries_only_on_rank_0(rank: int) -> None:
+    """
+    Previously, replicated entries were recorded under all ranks. Later, as an
+    optimization, replicated entries were only recorded under rank 0. This test
+    verifies that the optimization is backward compatible with the old format.
+    """
+    assert get_available_entries(_MANIFEST_0, rank) == get_available_entries(
+        _MANIFEST_1, rank
+    )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -5,8 +5,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import itertools
-import unittest
+
+from typing import Tuple
 
 import pytest
 
@@ -16,106 +16,85 @@ from torchsnapshot.serialization import (
     ALL_SUPPORTED_DTYPES,
     BUFFER_PROTOCOL_SUPPORTED_DTYPES,
     dtype_to_string,
-    per_channel_affine_qtensor_as_bytes,
-    per_channel_affine_qtensor_from_bytes,
-    per_tensor_affine_qtensor_as_bytes,
-    per_tensor_affine_qtensor_from_bytes,
+    per_channel_qtensor_as_bytes,
+    per_channel_qtensor_from_bytes,
+    per_tensor_qtensor_as_bytes,
+    per_tensor_qtensor_from_bytes,
     string_to_dtype,
+    SUPPORTED_QUANTIZED_DTYPES,
     tensor_as_memoryview,
     tensor_from_memoryview,
 )
 from torchsnapshot.test_utils import rand_tensor, tensor_eq
 
 
-class SerializationTest(unittest.TestCase):
-    def _test_buffer_protocol_helper(self, dtype: torch.dtype) -> None:
-        foo = rand_tensor(shape=(1000, 1000), dtype=dtype)
+@pytest.mark.parametrize("dtype", BUFFER_PROTOCOL_SUPPORTED_DTYPES)
+def test_buffer_protocol(dtype: torch.dtype) -> None:
+    foo = rand_tensor(shape=(1000, 1000), dtype=dtype)
 
-        serialized = tensor_as_memoryview(foo).tobytes()
-        dtype_str = dtype_to_string(foo.dtype)
-        shape = list(foo.shape)
+    serialized = tensor_as_memoryview(foo).tobytes()
+    dtype_str = dtype_to_string(foo.dtype)
+    shape = list(foo.shape)
 
-        bar = tensor_from_memoryview(
-            memoryview(serialized),
-            dtype=string_to_dtype(dtype_str),
+    bar = tensor_from_memoryview(
+        memoryview(serialized),
+        dtype=string_to_dtype(dtype_str),
+        shape=shape,
+    )
+    assert torch.allclose(foo, bar)
+
+
+@pytest.mark.parametrize("dtype", ALL_SUPPORTED_DTYPES)
+def test_string_dtype_conversion(dtype: torch.dtype) -> None:
+    dtype_str = dtype_to_string(dtype)
+    restored = string_to_dtype(dtype_str)
+    assert restored == dtype
+
+
+@pytest.mark.parametrize("dtype", SUPPORTED_QUANTIZED_DTYPES)
+@pytest.mark.parametrize("shape", [(100, 100), (10, 11, 12)])
+def test_per_tensor_qtensor(dtype: torch.dtype, shape: Tuple[int, ...]) -> None:
+    qtensor = rand_tensor(shape=shape, dtype=dtype)
+    buf = per_tensor_qtensor_as_bytes(qtensor)
+    deserialized = per_tensor_qtensor_from_bytes(buf, dtype=dtype, shape=list(shape))
+    assert qtensor.dtype == deserialized.dtype
+    assert qtensor.is_quantized
+    assert deserialized.is_quantized
+    assert qtensor.qscheme() == deserialized.qscheme()
+    assert qtensor.q_scale() == deserialized.q_scale()
+    assert qtensor.q_zero_point() == deserialized.q_zero_point()
+    assert qtensor.stride() == deserialized.stride()
+    assert torch.allclose(qtensor.dequantize(), deserialized.dequantize())
+
+
+@pytest.mark.parametrize("dtype", SUPPORTED_QUANTIZED_DTYPES)
+@pytest.mark.parametrize("shape", [(100, 100), (10, 11, 12)])
+def test_per_channel_qtensor(dtype: torch.dtype, shape: Tuple[int, ...]) -> None:
+    for axis in range(len(shape)):
+        qtensor = rand_tensor(
             shape=shape,
+            dtype=dtype,
+            qscheme=torch.per_channel_affine,
+            channel_axis=axis,
         )
-        self.assertTrue(torch.allclose(foo, bar))
-
-    def test_buffer_protocol(self) -> None:
-        for dtype in BUFFER_PROTOCOL_SUPPORTED_DTYPES:
-            with self.subTest(dtype=dtype):
-                self._test_buffer_protocol_helper(dtype)
-
-    def test_string_dtype_conversion(self) -> None:
-        for dtype in ALL_SUPPORTED_DTYPES:
-            with self.subTest(dtype=dtype):
-                dtype_str = dtype_to_string(dtype)
-                restored = string_to_dtype(dtype_str)
-                self.assertEqual(restored, dtype)
-
-    def test_per_tensor_affine_qtensor(self) -> None:
-        for shape, scale, zero_point, dtype in itertools.product(
-            [(100, 100), (10, 11, 12), (10, 11, 12, 13)],
-            [0.1, 0.2],
-            [1, 10],
-            [torch.qint32, torch.qint8, torch.quint8],
-        ):
-            qtensor = torch.quantize_per_tensor(
-                torch.rand(shape), scale, zero_point, dtype=dtype
-            )
-            buf = per_tensor_affine_qtensor_as_bytes(qtensor)
-            deserialized = per_tensor_affine_qtensor_from_bytes(
-                buf, dtype=dtype, shape=list(shape)
-            )
-            self.assertEqual(qtensor.dtype, deserialized.dtype)
-            self.assertTrue(qtensor.is_quantized)
-            self.assertTrue(deserialized.is_quantized)
-            self.assertEqual(qtensor.qscheme(), deserialized.qscheme())
-            self.assertEqual(qtensor.q_scale(), deserialized.q_scale())
-            self.assertEqual(qtensor.q_zero_point(), deserialized.q_zero_point())
-            self.assertEqual(qtensor.stride(), deserialized.stride())
-            self.assertTrue(
-                torch.allclose(qtensor.dequantize(), deserialized.dequantize())
-            )
-
-    def test_per_channel_affine_qtensor(self) -> None:
-        for shape, dtype in itertools.product(
-            [(100, 100), (10, 11, 12), (10, 11, 12, 13)],
-            [torch.qint32, torch.qint8, torch.quint8],
-        ):
-            for axis in range(len(shape)):
-                qtensor = torch.quantize_per_channel(
-                    torch.rand(shape),
-                    torch.rand(shape[axis]),
-                    torch.randint(128, (shape[axis],)),
-                    axis=axis,
-                    dtype=dtype,
-                )
-                buf = per_channel_affine_qtensor_as_bytes(qtensor)
-                deserialized = per_channel_affine_qtensor_from_bytes(
-                    buf, dtype=dtype, shape=list(shape)
-                )
-                self.assertEqual(qtensor.dtype, deserialized.dtype)
-                self.assertTrue(qtensor.is_quantized)
-                self.assertTrue(deserialized.is_quantized)
-                self.assertEqual(qtensor.qscheme(), deserialized.qscheme())
-                self.assertTrue(
-                    torch.allclose(
-                        qtensor.q_per_channel_scales(),
-                        deserialized.q_per_channel_scales(),
-                    )
-                )
-                self.assertTrue(
-                    torch.allclose(
-                        qtensor.q_per_channel_zero_points(),
-                        deserialized.q_per_channel_zero_points(),
-                    )
-                )
-                self.assertEqual(qtensor.stride(), deserialized.stride())
-                self.assertTrue(
-                    torch.allclose(qtensor.dequantize(), deserialized.dequantize())
-                )
+        buf = per_channel_qtensor_as_bytes(qtensor)
+        deserialized = per_channel_qtensor_from_bytes(
+            buf, dtype=dtype, shape=list(shape)
+        )
+        assert qtensor.dtype == deserialized.dtype
+        assert qtensor.is_quantized
+        assert deserialized.is_quantized
+        assert qtensor.qscheme(), deserialized.qscheme()
+        assert torch.allclose(
+            qtensor.q_per_channel_scales(),
+            deserialized.q_per_channel_scales(),
+        )
+        assert torch.allclose(
+            qtensor.q_per_channel_zero_points(),
+            deserialized.q_per_channel_zero_points(),
+        )
+        assert qtensor.stride() == deserialized.stride()
+        assert torch.allclose(qtensor.dequantize(), deserialized.dequantize())
 
 
 @pytest.mark.parametrize("dtype", BUFFER_PROTOCOL_SUPPORTED_DTYPES)

--- a/torchsnapshot/io_preparer.py
+++ b/torchsnapshot/io_preparer.py
@@ -318,7 +318,7 @@ class ShardedTensorIOPreparer:
         else:
             out_shape = list(obj_out.shape)
         if out_shape != global_shape:
-            logger.warn(
+            logger.warning(
                 f"The shape of obj_out ({out_shape}) is different from the "
                 f"shape of the persisted sharded tensor ({global_shape}). "
                 "Only the overlapping part will be loaded. "

--- a/torchsnapshot/manifest.py
+++ b/torchsnapshot/manifest.py
@@ -368,8 +368,11 @@ def get_available_entries(manifest: Manifest, rank: int) -> Manifest:
         # The logical path corresponds to a replicated entry
         if is_replicated(entries[0]):
             local_manifest.setdefault(logical_path, entries[0])
-        # The logical path corresponds to a ShardedTensor entry
+        # The logical path corresponds to a ShardedTensorEntry
         elif isinstance(entries[0], ShardedTensorEntry):
+            # TODO: on save, we should enforce the following invariants that if
+            # a logical path on one rank is a ShardedTensorEntry, the logical
+            # path on all ranks that has the logical path is a ShardedTensorEntry.
             local_manifest[logical_path] = ShardedTensorEntry(
                 shards=[
                     shard


### PR DESCRIPTION
Summary:
- Removed "affine" from the serializer names affine vs. symmetric doesn't matter for serialization
- Added buffer size validation logic
- Adjusted the binary layout of per_channel_qtensor for the ease of validation (no BC issue since the serializer is not yet in use)
- Moved the tests to pytest

Differential Revision: D40190016

