### PR TITLE
move doc builds to subfolder

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -10,36 +10,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit_tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v2
-      - name: Setup conda env
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: "latest"
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        shell: bash -l {0}
-        run: |
-          set -eux
-          conda activate test
-          conda install pytorch cpuonly -c pytorch-nightly
-          pip install -r requirements.txt
-          pip install -r dev-requirements.txt
-          python setup.py sdist bdist_wheel
-          pip install dist/*.whl
-      - name: Run unit tests
-        shell: bash -l {0}
-        run: |
-          set -eux
-          conda activate test
-          pytest tests -vv
   build_docs:
     needs: unit_tests
     runs-on: ubuntu-latest
@@ -68,8 +38,8 @@ jobs:
           conda activate test
           cd docs
           pip install -r requirements.txt
-          make html
-          touch build/html/.nojekyll
+          sphinx-build -b html source build/html/main
+          touch build/html/main/.nojekyll
           cd ..
       - name: Deploy docs to Github pages
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,12 @@ copyright = "2022, Meta"
 author = "Meta"
 
 # The full version, including alpha/beta/rc tags
-release = __version__
+if os.environ.get("RELEASE_BUILD", None):
+    version = __version__
+    release = __version__
+else:
+    version = "main (unstable)"
+    release = "main"
 
 
 # -- General configuration ---------------------------------------------------
@@ -61,6 +66,10 @@ exclude_patterns = []
 #
 html_theme = "pytorch_sphinx_theme"
 html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
+
+html_theme_options = {
+    "display_version": True,
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/torchsnapshot/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:

instead of the files being stored directly, move to `main`. when torchsnapshot gets a full release, a `stable` symlink can point to the directory of the latest version (e.g. `0.0.3/`).

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->
