### PR TITLE
reconstruct the original state dict on load

### DIFF
--- a/torchsnapshot/flatten.py
+++ b/torchsnapshot/flatten.py
@@ -135,7 +135,7 @@ def inflate(
                 f"inflate() does not know how to inflate container of type {type(containers[path])} "
                 f"(path: {path}, container entry: {manifest.get(path)})."
             )
-        _populate_container(container=containers[path], values=values)
+        _populate_container(path=path, container=containers[path], values=values)
     return containers[prefix]
 
 
@@ -173,7 +173,7 @@ def _entry_to_container(entry: Entry) -> Any:
         )
 
 
-def _populate_container(container: Any, values: Dict[str, Any]) -> None:
+def _populate_container(path: str, container: Any, values: Dict[str, Any]) -> None:
     if isinstance(container, list):
         items = sorted(values.items(), key=lambda e: int(e[0]))
         container.extend(item[1] for item in items)
@@ -183,7 +183,10 @@ def _populate_container(container: Any, values: Dict[str, Any]) -> None:
             if key not in container and _check_int(key):
                 key = int(key)
             if key not in container:
-                raise RuntimeError("TODO")
+                raise RuntimeError(
+                    f"{key} is not a valid key of container {path} "
+                    f"(valid keys: {list(container.keys())})."
+                )
             container[key] = obj
     else:
         raise AssertionError(f"Unrecognized container type: {type(container)}.")


### PR DESCRIPTION
Summary:
Previous, on `.restore()`, we retrieve the state dict of the target stateful, restore its values in-place, and use the state dict to invoke the target stateful's `.load_state_dict()`.

This approach has a flaw: sometimes it's valid for the persisted state dict to have a different structure compared to the target stateful's state dict, in which case the correct behavior is to reconstruct the persisted state dict.

This diff changes the following:
- `get_available_entry()` now returns the container entries for reconstructing the persisted state dict
- `.load_stateful()` would still in-place load tensors that are found in the target stateful's state dict. But it would also load tensors that are not found in the target stateful's state dict
- The state dict is now inflated with the persisted container entries as opposed to the target stateful's container entries

Differential Revision: D40462737

