### PR TITLE
Have prepare_read() functions return a future

### DIFF
--- a/tests/test_batcher.py
+++ b/tests/test_batcher.py
@@ -296,7 +296,7 @@ async def test_batcher(
     # Prepare read requests for the dst tensors
     read_reqs = []
     for entry, obj_out in zip(entries, dst_tensors + [None] * NUM_TENSORS):
-        rrs = prepare_read(
+        rrs, _ = prepare_read(
             entry=entry,
             obj_out=obj_out,
             buffer_size_limit_bytes=read_chunk_size_bytes

--- a/tests/test_chunked_tensor_io_preparer.py
+++ b/tests/test_chunked_tensor_io_preparer.py
@@ -226,7 +226,7 @@ class ChunkedTensorIOPreparerTest(unittest.TestCase):
             await pending_io_work.complete()
 
             buffer_size_limit_bytes = src.nelement() * src.element_size() // 4
-            read_reqs = ChunkedTensorIOPreparer.prepare_read(
+            read_reqs, _ = ChunkedTensorIOPreparer.prepare_read(
                 entry=entry,
                 tensor_out=dst,
                 buffer_size_limit_bytes=buffer_size_limit_bytes,

--- a/tests/test_partitioner.py
+++ b/tests/test_partitioner.py
@@ -261,7 +261,7 @@ async def test_partitioner(  # noqa
         assert not tensor_eq(tensor, dst_tensor)
 
         entry = partitioned_entries[logical_path]
-        rrs = prepare_read(entry, obj_out=dst_tensor)
+        rrs, _ = prepare_read(entry, obj_out=dst_tensor)
         for rr in rrs:
             read_io = ReadIO(path=rr.path, byte_range=rr.byte_range)
             await plugin.read(read_io)

--- a/tests/test_sharded_tensor_io_preparer.py
+++ b/tests/test_sharded_tensor_io_preparer.py
@@ -169,7 +169,7 @@ async def test_sharded_tensor_io_preparer(
 
     # Consume the buffers with dst and verify that src == dst
     assert not tensor_eq(src, dst)
-    read_reqs = ShardedTensorIOPreparer.prepare_read(entry=entry, obj_out=dst)
+    read_reqs, _ = ShardedTensorIOPreparer.prepare_read(entry=entry, obj_out=dst)
     for rr in read_reqs:
         await rr.buffer_consumer.consume_buffer(buf=location_to_buf[rr.path])
     assert tensor_eq(src, dst)

--- a/tests/test_sharded_tensor_resharding.py
+++ b/tests/test_sharded_tensor_resharding.py
@@ -96,7 +96,7 @@ async def test_sharded_tensor_resharding(
     entry, write_reqs = ShardedTensorIOPreparer.prepare_write(
         storage_path="src", obj=src
     )
-    read_reqs = ShardedTensorIOPreparer.prepare_read(entry=entry, obj_out=dst)
+    read_reqs, _ = ShardedTensorIOPreparer.prepare_read(entry=entry, obj_out=dst)
 
     # Fulfill the dst's read requests with src's write requests
     path_to_buf = {wr.path: await wr.buffer_stager.stage_buffer() for wr in write_reqs}

--- a/tests/test_tensor_io_preparer.py
+++ b/tests/test_tensor_io_preparer.py
@@ -92,7 +92,7 @@ class TensorIOPreparerTest(unittest.TestCase):
             dtype in BUFFER_PROTOCOL_SUPPORTED_DTYPES,
         )
 
-        read_reqs = TensorIOPreparer.prepare_read(entry=entry, tensor_out=bar)
+        read_reqs, _ = TensorIOPreparer.prepare_read(entry=entry, tensor_out=bar)
         self._fulfill_read_reqs_with_write_reqs(
             read_reqs=read_reqs, write_reqs=write_reqs
         )
@@ -140,7 +140,7 @@ class TensorIOPreparerTest(unittest.TestCase):
             await pending_io_work.complete()
 
             buffer_size_limit_bytes = src.nelement() * src.element_size() // 4
-            read_reqs = TensorIOPreparer.prepare_read(
+            read_reqs, _ = TensorIOPreparer.prepare_read(
                 entry=entry,
                 tensor_out=dst,
                 buffer_size_limit_bytes=buffer_size_limit_bytes,

--- a/torchsnapshot/io_types.py
+++ b/torchsnapshot/io_types.py
@@ -10,7 +10,7 @@ import asyncio
 import io
 from concurrent.futures import Executor
 from dataclasses import dataclass, field
-from typing import Optional, Tuple, Union
+from typing import Generic, Optional, Tuple, TypeVar, Union
 
 
 BufferType = Union[bytes, memoryview]
@@ -49,6 +49,14 @@ class ReadReq:
     path: str
     buffer_consumer: BufferConsumer
     byte_range: Optional[Tuple[int, int]] = None
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class Future(Generic[T]):
+    obj: Optional[T] = None
 
 
 @dataclass


### PR DESCRIPTION
Summary:
Motivations:
- Better consistency for in-place loadable and non-in-place loadable objects
- Can potentially defer output allocation after reading from storage

Reviewed By: raypeng

Differential Revision: D40626024

