### PR TITLE
Delete stub file to enable mypy check (#4649)

### DIFF
--- a/tests/test_ddp_infer_replication.py
+++ b/tests/test_ddp_infer_replication.py
@@ -60,7 +60,7 @@ class DDPInferReplicatedTest(unittest.TestCase):
     ) -> None:
         dist.init_process_group(backend="gloo")
         model = torch.nn.Sequential(torch.nn.Linear(4, 2), torch.nn.Linear(2, 1))
-        DDP._set_params_and_buffers_to_ignore_for_model(  # pyre-ignore[16]
+        DDP._set_params_and_buffers_to_ignore_for_model(
             model, ["module.0.bias", "module.0.weight"]
         )
         ddp_model = DDP(model)
@@ -86,7 +86,7 @@ class DDPInferReplicatedTest(unittest.TestCase):
     ) -> None:
         dist.init_process_group(backend="gloo")
         model = torch.nn.Sequential(torch.nn.Linear(4, 2), torch.nn.Linear(2, 1))
-        DDP._set_params_and_buffers_to_ignore_for_model(  # pyre-ignore[16]
+        DDP._set_params_and_buffers_to_ignore_for_model(
             model, ["module.0.bias", "module.0.weight"]
         )
         ddp_model = DDP(model)


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookresearch/detectron2/pull/4649

Context in https://fburl.com/4irjskbe

This change deletes distributed.pyi, so that lintrunner will run mypy on distributed.py for typing check.

Differential Revision: D41028360

