### PR TITLE
Move instance of params from TBE fused kernels to named_parameters

### DIFF
--- a/examples/torchrec/main.py
+++ b/examples/torchrec/main.py
@@ -25,6 +25,7 @@ from torchrec.distributed.planner.types import ParameterConstraints
 from torchrec.distributed.types import ShardingPlan, ShardingType
 from torchrec.models.dlrm import DLRM, DLRMTrain
 from torchrec.optim.keyed import KeyedOptimizerWrapper
+from torchrec.optim.optimizers import in_backward_optimizer_filter
 
 EPOCH_SIZE = 10
 BATCH_SIZE = 8
@@ -126,7 +127,7 @@ def train(work_dir: str, max_epochs: int, snapshot_path: Optional[str] = None) -
     )
 
     optimizer = KeyedOptimizerWrapper(
-        dict(dmp.named_parameters()),
+        dict(in_backward_optimizer_filter(dmp.named_parameters())),
         lambda params: torch.optim.SGD(params, lr=0.01),
     )
 


### PR DESCRIPTION
Summary:
Fixing long standing nit bug with TorchRec's named parameters not returning fused parameters.

Model code needs to change to account for this, we do this by adding the filter_optimizer_in_backward_named_parameters

This sets the stage for the composability change

The important parts to change, being MVAI/O3/PyPer should have this change. Tried to get everything else,

Most important files to look at IMO are

* full_sync_optimizer.py
* fbcode/torchrec/optim/optimizers.py
* torchrec/fb/optim/module_optimizer.py

Differential Revision: D41964643

