### PR TITLE
Fix requirements file for nightly builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ aiohttp
 importlib-metadata
 nest_asyncio
 psutil
+pyre_extensions
 torch
 typing-extensions


### PR DESCRIPTION
Summary:
CI is failing due to a missing requirement:

```
E   ModuleNotFoundError: No module named 'pyre_extensions'
```
https://github.com/pytorch/torchsnapshot/actions/runs/4731726323/jobs/8396999333

adding this explicitly as a requirement for snapshot

Differential Revision: D45101250

