### PR TITLE
Check failing UVM test

### DIFF
--- a/tests/test_uvm_tensor.py
+++ b/tests/test_uvm_tensor.py
@@ -20,10 +20,12 @@ from torchsnapshot.uvm_tensor import (
 @pytest.mark.cpu_and_gpu
 def test_uvm_tensor() -> None:
     if torch.cuda.is_available() and _UVM_TENSOR_AVAILABLE:
+        device = torch.device("cuda:0")
+        torch.cuda.set_device(device)
         uvm_tensor = torch.rand(
             (64, 64),
             out=new_managed_tensor(
-                torch.empty(0, dtype=torch.float32, device="cuda:0"),
+                torch.empty(0, dtype=torch.float32, device=device),
                 [64, 64],
             ),
         )


### PR DESCRIPTION
Summary:
see if this fixes the error
```
tests/test_uvm_tensor.py::test_uvm_tensor - RuntimeError: CUDA error: invalid device ordinal
```
https://github.com/pytorch/torchsnapshot/actions/runs/5422322107/jobs/9858818161

Differential Revision: D47158196

