### PR TITLE
Change torch and fbgemm-gpu version

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -73,12 +73,12 @@ jobs:
         run: |
           set -eux
           conda activate test
-          pip install torch --extra-index-url https://download.pytorch.org/whl/cu116
+          conda install pytorch pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
           pip install torchrec-nightly
 
           # Use stable fbgemm-gpu
-          pip uninstall -y fbgemm-gpu-nightly
-          pip install fbgemm-gpu
+          # pip uninstall -y fbgemm-gpu-nightly
+          # pip install fbgemm-gpu-nightly
 
           pip install -r requirements.txt
           pip install -r dev-requirements.txt


### PR DESCRIPTION
Summary: Version mismatch between fbgemm-gpu and torch can cause errors. Debug to see if the problem persists if the compatible version (i.e., nightly) is used.

Differential Revision: D48460839

