### PR TITLE
Default sharded tensor elasticity check

### DIFF
--- a/examples/torchrec/main.py
+++ b/examples/torchrec/main.py
@@ -101,6 +101,7 @@ def get_rowwise_sharding_plan(
 
 
 def train(work_dir: str, max_epochs: int, snapshot_path: Optional[str] = None) -> None:
+    os.environ["TORCHSNAPSHOT_ENABLE_SHARDED_TENSOR_ELASTICITY_ROOT_ONLY"] = "1"
     dist.init_process_group(backend="nccl")
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device(f"cuda:{local_rank}")

--- a/torchsnapshot/knobs.py
+++ b/torchsnapshot/knobs.py
@@ -25,7 +25,10 @@ _SLAB_SIZE_THRESHOLD_ENV_VAR = "TORCHSNAPSHOT_SLAB_SIZE_THRESHOLD_BYTES_OVERRIDE
 _DEFAULT_MAX_CHUNK_SIZE_BYTES: int = 512 * 1024 * 1024
 _DEFAULT_MAX_SHARD_SIZE_BYTES: int = 512 * 1024 * 1024
 _DEFAULT_SLAB_SIZE_THRESHOLD_BYTES: int = 128 * 1024 * 1024
-_DISABLE_BATCHING_ENV_VAR = "TORCHSNAPSHOT_DISABLE_BATCHING"
+_DISABLE_BATCHING_ENV_VAR: str = "TORCHSNAPSHOT_DISABLE_BATCHING"
+_ENABLE_SHARDED_TENSOR_ELASTICITY_ROOT_ENV_VAR: str = (
+    "TORCHSNAPSHOT_ENABLE_SHARDED_TENSOR_ELASTICITY_ROOT_ONLY"
+)
 
 
 def get_max_chunk_size_bytes() -> int:
@@ -49,8 +52,17 @@ def get_slab_size_threshold_bytes() -> int:
     return _DEFAULT_SLAB_SIZE_THRESHOLD_BYTES
 
 
-def is_batching_disabled() -> int:
+def is_batching_disabled() -> bool:
     if os.getenv(_DISABLE_BATCHING_ENV_VAR, "False").lower() in ("true", "1"):
+        return True
+    return False
+
+
+def is_sharded_tensor_elasticity_enabled_at_root_only() -> bool:
+    if os.getenv(_ENABLE_SHARDED_TENSOR_ELASTICITY_ROOT_ENV_VAR, "False").lower() in (
+        "true",
+        "1",
+    ):
         return True
     return False
 


### PR DESCRIPTION
Summary:
Currently for sharded tensor elasticity, torchsnapshot only searches for sharded tensors at the root of the state dict. As the note in the comment indicates, this means elasticity for most optimizers is not supported. This change aims to lift this restriction.

This change in default behavior can be toggled off by setting `TORCHSNAPSHOT_ENABLE_SHARDED_TENSOR_ELASTICITY_ROOT_ONLY=1`

Differential Revision: D49620100


