### PR TITLE
Add convenience class for DDP/non-DDP loading

### DIFF
--- a/torchsnapshot/tricks/ddp.py
+++ b/torchsnapshot/tricks/ddp.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+import torch
+
+DDP_STATE_DICT_PREFIX: str = "module."
+
+
+class DistributedDataParallelAdapter:
+    """
+    A convenience class to load a module's state dict saved from a DistributedDataParallel-wrapped module into a module that is not wrapped with DDP.
+
+    Example::
+
+        >>> module = torch.nn.Linear(2, 2)
+        >>> ddp_module = DistributedDataParallel(module)
+        >>> Snapshot.take(
+        >>>     path="foo/bar",
+        >>>     app_state={"module": ddp_module},
+        >>> )
+
+        >>> # Restore the state
+        >>> snapshot = Snapshot(path="foo/bar")
+        >>> adaptor = DistributedDataParallelAdapter(module)
+        >>> snapshot.restore({"module": adaptor})
+        >>> module = adaptor.module
+    """
+
+    def __init__(self, module: torch.nn.Module) -> None:
+        self.module = module
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.module.state_dict()
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        torch.nn.modules.utils.consume_prefix_in_state_dict_if_present(
+            state_dict, DDP_STATE_DICT_PREFIX
+        )
+        self.module.load_state_dict(state_dict)


### PR DESCRIPTION
Summary:
Leverage utility function here: https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html?highlight=distributeddataparallel#torch.nn.parallel.DistributedDataParallel

as part of a convenience where users have saved a module wrapped with DDP and want to restore the states into a non-DDP wrapped module.

Differential Revision: D48696303


