### PR TITLE
Add snapshot test for FSDP model + opt

### DIFF
--- a/tests/gpu_tests/test_snapshot_fsdp.py
+++ b/tests/gpu_tests/test_snapshot_fsdp.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from pathlib import Path
+
+import pytest
+
+import torch
+import torch.distributed as dist
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, StateDictType
+from torchsnapshot import Snapshot
+from torchsnapshot.test_utils import check_state_dict_eq, run_with_pet
+from torchsnapshot.tricks.fsdp import FSDPOptimizerAdapter
+
+
+def _create_fsdp_model(
+    seed: int,
+    device: torch.device,
+    state_dict_type: StateDictType = StateDictType.FULL_STATE_DICT,
+) -> torch.nn.Module:
+    torch.manual_seed(seed)
+    model = torch.nn.Sequential(
+        torch.nn.Linear(128, 64),
+        torch.nn.Linear(64, 32),
+        torch.nn.Linear(32, 16),
+    )
+
+    fsdp_model = FSDP(
+        module=model,
+        device_id=device,
+    )
+    FSDP.set_state_dict_type(fsdp_model, state_dict_type)
+    return fsdp_model
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="The test requires GPUs to run."
+)
+@pytest.mark.gpu_only
+@pytest.mark.usefixtures("toggle_batching")
+# Sharded state dict will test ShardedTensors, full tests Tensors
+@pytest.mark.parametrize(
+    "state_dict_type", [StateDictType.FULL_STATE_DICT, StateDictType.SHARDED_STATE_DICT]
+)
+@run_with_pet(nproc=2)
+def test_model_and_optim_fsdp(tmp_path: Path, state_dict_type: StateDictType) -> None:
+    dist.init_process_group(backend="nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+
+    foo_fsdp = _create_fsdp_model(
+        seed=42,
+        device=device,
+        state_dict_type=state_dict_type,
+    )
+    bar_fsdp = _create_fsdp_model(
+        seed=777 + dist.get_rank(),
+        device=device,
+        state_dict_type=state_dict_type,
+    )
+
+    assert not check_state_dict_eq(foo_fsdp.state_dict(), bar_fsdp.state_dict())
+
+    # Need to step and zero_grad in order to initialize all the optimizer parameters
+    foo_optim = torch.optim.AdamW(foo_fsdp.parameters(), lr=0.01)
+    foo_optim.step(closure=None)
+    foo_optim.zero_grad(set_to_none=True)
+
+    bar_optim = torch.optim.AdamW(bar_fsdp.parameters(), lr=0.02)
+    bar_optim.step(closure=None)
+    bar_optim.zero_grad(set_to_none=True)
+
+    foo_fsdp_optim = FSDPOptimizerAdapter(foo_fsdp, foo_optim)
+    bar_fsdp_optim = FSDPOptimizerAdapter(bar_fsdp, bar_optim)
+
+    assert not check_state_dict_eq(
+        foo_fsdp_optim.state_dict(), bar_fsdp_optim.state_dict()
+    )
+
+    foo_app_state = {"foo": foo_fsdp, "optim": foo_fsdp_optim}
+
+    snapshot = Snapshot.take(str(tmp_path), foo_app_state)
+    snapshot.restore({"foo": bar_fsdp, "optim": bar_fsdp_optim})
+
+    assert check_state_dict_eq(foo_fsdp_optim.state_dict(), bar_fsdp_optim.state_dict())
+    assert check_state_dict_eq(foo_fsdp.state_dict(), bar_fsdp.state_dict())

--- a/torchsnapshot/tricks/ddp.py
+++ b/torchsnapshot/tricks/ddp.py
@@ -27,9 +27,9 @@ class DistributedDataParallelAdapter:
 
         >>> # Restore the state
         >>> snapshot = Snapshot(path="foo/bar")
-        >>> adaptor = DistributedDataParallelAdapter(module)
-        >>> snapshot.restore({"module": adaptor})
-        >>> module = adaptor.module
+        >>> adapter = DistributedDataParallelAdapter(module)
+        >>> snapshot.restore({"module": adapter})
+        >>> module = adapter.module
     """
 
     def __init__(self, module: torch.nn.Module) -> None:

--- a/torchsnapshot/tricks/fsdp.py
+++ b/torchsnapshot/tricks/fsdp.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+import torch
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+
+class FSDPOptimizerAdapter:
+    """
+    Wrapper for FSDP optimizer to call specific FSDP optimizer state checkpointing APIs.
+
+    Example::
+
+        >>> module = torch.nn.Linear(2, 2)
+        >>> fsdp_module = FullyShardedDataParallel(module)
+        >>> optimizer = torch.optim.SGD(fsdp_module.parameters(), lr=0.1)
+        >>> Snapshot.take(
+        >>>     path="foo/bar",
+        >>>     app_state={"module": fsdp_module, "optim": FSDPOptimizerAdapter(fsdp_module, optimizer)},
+        >>> )
+
+        >>> # Restore the state
+        >>> snapshot = Snapshot(path="foo/bar")
+        >>> module = torch.nn.Linear(2, 2)
+        >>> fsdp_module = FullyShardedDataParallel(module)
+        >>> optimizer = torch.optim.SGD(fsdp_module.parameters(), lr=0.1)
+        >>> adapter = FSDPOptimizerAdapter(module)
+        >>> snapshot.restore({"module": module, "optim": FSDPOptimizerAdapter(fsdp_module, optimizer)})
+    """
+
+    def __init__(self, module: FSDP, optimizer: torch.optim.Optimizer) -> None:
+        self.module = module
+        self.optimizer = optimizer
+
+    def state_dict(self) -> Dict[str, Any]:
+        optim_state_dict = FSDP.optim_state_dict(self.module, self.optimizer)
+        return optim_state_dict
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        optim_state_dict = FSDP.optim_state_dict_to_load(
+            self.module, self.optimizer, state_dict
+        )
+        self.optimizer.load_state_dict(optim_state_dict)


### PR DESCRIPTION
Summary: Two quick and dirty torchsnapshot tests for an FSDP module + preinitialized opt and a normal module + preinit opt, since they were absent from the test suite.

Reviewed By: ananthsub

Differential Revision: D49555242

