### PR TITLE
Use untyped storage API in serialization

### DIFF
--- a/torchsnapshot/serialization.py
+++ b/torchsnapshot/serialization.py
@@ -219,7 +219,9 @@ def contiguous_view_as_untyped_storage(tensor: torch.Tensor) -> UntypedStorage:
             "contiguous_view_as_untyped_storage can be "
             "only used with contiguous tensors."
         )
-    if hasattr(tensor.storage(), "_untyped"):
+    if hasattr(tensor, "untyped_storage"):
+        untyped_storage = tensor.untyped_storage()
+    elif hasattr(tensor.storage(), "_untyped"):
         # TODO: drop this once PyTorch 1.12 is no longer supported
         # https://github.com/pytorch/pytorch/pull/82438
         untyped_storage = tensor.storage()._untyped()


### PR DESCRIPTION
Summary:
Directly use the untyped storage APIs from tensors: https://pytorch.org/docs/stable/generated/torch.Tensor.untyped_storage.html#torch.Tensor.untyped_storage

This resolves deprecation warnings people have in logs

Differential Revision: D49969508


