### PR TITLE
Rename get_dim_groups to get_group

### DIFF
--- a/tests/gpu_tests/test_snapshot_dtensor.py
+++ b/tests/gpu_tests/test_snapshot_dtensor.py
@@ -70,8 +70,8 @@ class TestSnapshotWithDTensor(DTensorTestBase):
             )
         else:
             mesh_2d = init_device_mesh("cuda", (2, WORLD_SIZE // 2))
-            intra_node_pg = mesh_2d.get_dim_groups(mesh_dim=1)
-            inter_node_pg = mesh_2d.get_dim_groups(mesh_dim=0)
+            intra_node_pg = mesh_2d.get_group(mesh_dim=1)
+            inter_node_pg = mesh_2d.get_group(mesh_dim=0)
             model = FSDP(
                 DummyModel().cuda(),
                 process_group=(intra_node_pg, inter_node_pg),


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch/pytorch/pull/114708

Rename get_dim_groups to get_group and update all callsites.
ghstack-source-id: 208606443
exported-using-ghexport

Differential Revision: D51629801


