### PR TITLE
add sharded tensor support to read_object when obj_out=None

### DIFF
--- a/tests/test_read_object.py
+++ b/tests/test_read_object.py
@@ -67,9 +67,19 @@ class ReadObjectTest(unittest.TestCase):
                 path=path, app_state={"state": torchsnapshot.StateDict(foo=foo)}
             )
             snapshot.read_object("0/state/foo", obj_out=bar)
+            baz = snapshot.read_object("0/state/foo")
 
         for foo_shard, bar_shard in zip(foo.local_shards(), bar.local_shards()):
             tc.assertTrue(torch.allclose(foo_shard.tensor, bar_shard.tensor))
+
+        tc.assertEqual(baz.shape, torch.Size([20_000, 128]))
+
+        gathered_foo_tensor = torch.empty(20_000, 128)
+        if dist.get_rank() == 0:
+            foo.gather(dst=0, out=gathered_foo_tensor)
+            tc.assertTrue(torch.allclose(baz, gathered_foo_tensor))
+        else:
+            foo.gather(dst=0, out=None)
 
     def test_read_sharded_tensor(self) -> None:
         lc = get_pet_launch_config(nproc=4)

--- a/torchsnapshot/snapshot.py
+++ b/torchsnapshot/snapshot.py
@@ -28,6 +28,8 @@ from torch.distributed._shard.sharded_tensor import ShardedTensor
 from torch.distributed._tensor import DTensor
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torchsnapshot.dtensor_utils import is_sharded
+from torchsnapshot.manifest import ShardedTensorEntry
+from torchsnapshot.serialization import string_to_dtype
 
 from .batcher import batch_read_requests, batch_write_requests
 
@@ -384,8 +386,9 @@ class Snapshot:
                 type. Otherwise, ``obj_out`` is ignored.
 
                 .. note::
-                    When the target object is a ``ShardedTensor``, ``obj_out``
-                    must be specified.
+                    When the target object is a ``ShardedTensor``, and ``obj_out``
+                    is None, will return cpu, full tensor version of the sharded
+                    tensor.
 
             memory_budget_bytes (int, optional): When specified, the read
                 operation will keep the temporary memory buffer size below this
@@ -435,6 +438,25 @@ class Snapshot:
         entry = merged_sd_entries.get(unranked_path) or manifest[unranked_path]
         if isinstance(entry, PrimitiveEntry):
             return cast(T, entry.get_value())
+        elif obj_out is None and isinstance(entry, ShardedTensorEntry):
+            # construct tensor for `obj_out` to fill in-place
+            # by reading shard metadata
+            first_shard = entry.shards[0]
+            shape = [
+                size + offset
+                for size, offset in zip(first_shard.sizes, first_shard.offsets)
+            ]
+            dtype = entry.shards[0].tensor.dtype
+            for shard in entry.shards[1:]:
+                size = shard.sizes
+                offset = shard.offsets
+                # sum element-wise
+                candidate_shape = [x + y for x, y in zip(size, offset)]
+                if all(x >= y for x, y in zip(candidate_shape, shape)):
+                    shape = candidate_shape
+            tensor = torch.empty(shape, dtype=string_to_dtype(dtype))
+            obj_out = tensor
+
         read_reqs, fut = prepare_read(
             entry=entry,
             obj_out=obj_out,


### PR DESCRIPTION
Summary:
# Context
It is currently not possible to read a sharded tensor directly from snapshot without constructing a sharded tensor manually and passing via `obj_out` in `read_object`. 

# This Diff
Modifies the `read_object` function by calculating the sharded tensor's size (the largest  offsets + sizes tuple) and sets `obj_out` to a cpu, regular tensor of that size.

Reviewed By: RdoubleA, yifuwang

Differential Revision: D52258262


