### PR TITLE
Fix for getting socket name for IPv4 addresses

### DIFF
--- a/torchsnapshot/dist_store.py
+++ b/torchsnapshot/dist_store.py
@@ -66,7 +66,8 @@ def create_store(pg_wrapper: PGWrapper) -> dist.Store:
     if pg_wrapper.get_rank() == 0:
         # Find a free port
         sock = get_socket_with_port()
-        master_addr, master_port, _, _ = sock.getsockname()
+        address = sock.getsockname()
+        master_addr, master_port = address[0], address[1]
         sock.close()
         # Broadcast master address/port to peers
         obj_list = [master_addr, master_port]


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/torchsnapshot/blob/main/CONTRIBUTING.md) prior to creating your pull request.

Summary:
<!-- Change Summary -->



`sock.getsockname` currently expects the address to always be IPV6. An IPv4 address returns two arguments instead of four. This PR fixes that.

Test plan:
<!--  How you tested the change, ideally with a unit test :) -->

Not sure how to test this. Would be happy to help if needed.

Fixes #{issue number}
<!-- Link the issue this pull request fixes -->

Closes #178 
